### PR TITLE
feat: per-container Claude state + runtime home-manager switch

### DIFF
--- a/container/Containerfile
+++ b/container/Containerfile
@@ -38,6 +38,10 @@ ENV PATH="/home/dev/.npm-global/bin:/home/dev/.local/bin:/home/dev/.nix-profile/
 RUN mkdir -p /home/dev/.config/nix \
     && echo "experimental-features = nix-command flakes" > /home/dev/.config/nix/nix.conf
 
+# Allow git operations on the dotfiles clone at runtime under --userns=keep-id
+# (the runtime uid may differ from the build uid, which git treats as dubious).
+RUN git config --global --add safe.directory /home/dev/.dotfiles
+
 # Pre-fetch flake inputs (big download — cached in this layer if flake.lock unchanged)
 RUN cd /home/dev/.dotfiles/nix && nix flake archive --no-write-lock-file
 

--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -17,6 +17,29 @@ if [ -n "${DEV_MOUNT:-}" ] && [ -d "$DEV_MOUNT" ]; then
   [ ! -e "$HOME/$LINK_NAME" ] && ln -sfn "$DEV_MOUNT" "$HOME/$LINK_NAME"
 fi
 
+# Wire up persistent Claude state.
+# home-manager (at build time) owns the static ~/.claude/* config as symlinks
+# into ~/.dotfiles. Here we link the runtime-generated state subpaths to the
+# mounted per-container state dir so memory, session history, todos and plugins
+# persist on the host. We never touch the static config entries.
+STATE=/home/dev/.claude-state
+if [ -d "$STATE" ]; then
+  mkdir -p "$HOME/.claude"
+  for p in projects todos plugins; do
+    mkdir -p "$STATE/$p"
+    ln -sfn "$STATE/$p" "$HOME/.claude/$p"
+  done
+  [ -e "$STATE/history.jsonl" ] || : > "$STATE/history.jsonl"
+  ln -sfn "$STATE/history.jsonl" "$HOME/.claude/history.jsonl"
+fi
+
+# Share the single canonical host credentials file (mounted by the launcher).
+if [ -e /home/dev/.claude-cred.json ]; then
+  mkdir -p "$HOME/.claude"
+  ln -sfn /home/dev/.claude-cred.json "$HOME/.claude/.credentials.json"
+  chmod 600 /home/dev/.claude-cred.json 2>/dev/null || true
+fi
+
 # Fix git credential helper for container context
 git config --global credential.helper "!$(which gh) auth git-credential"
 

--- a/files/home/.claude/.gitignore
+++ b/files/home/.claude/.gitignore
@@ -1,0 +1,14 @@
+# Never commit runtime-generated Claude state, even if it lands in this subtree.
+# (The repo-root /.claude/ rule does not cover files/home/.claude/.)
+.credentials*
+*.jsonl
+history*
+projects/
+sessions/
+memory/
+todos/
+plugins/
+shell-snapshots/
+file-history/
+paste-cache/
+statsig/

--- a/files/home/.claude/settings.json
+++ b/files/home/.claude/settings.json
@@ -25,7 +25,7 @@
   },
   "statusLine": {
     "type": "command",
-    "command": "bash /Users/quinnherden/.claude/statusline-command.sh"
+    "command": "bash ~/.claude/statusline-command.sh"
   },
   "enabledPlugins": {
     "frontend-design@claude-plugins-official": true,

--- a/files/home/.claude/statusline-command.sh
+++ b/files/home/.claude/statusline-command.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+input=$(cat)
+
+user=$(whoami)
+host=$(hostname -s)
+dir=$(echo "$input" | jq -r '.workspace.current_dir')
+model=$(echo "$input" | jq -r '.model.display_name')
+used=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
+
+git_branch=""
+if git -C "$dir" rev-parse --git-dir > /dev/null 2>&1; then
+  branch=$(git -C "$dir" symbolic-ref --short HEAD 2>/dev/null || git -C "$dir" rev-parse --short HEAD 2>/dev/null)
+  [ -n "$branch" ] && git_branch=" [$branch]"
+fi
+
+ctx=""
+[ -n "$used" ] && ctx=" ctx:$(printf '%.0f' "$used")%"
+
+printf "%s@%s %s%s | %s%s\n" "$user" "$host" "$dir" "$git_branch" "$model" "$ctx"

--- a/files/scripts/dev
+++ b/files/scripts/dev
@@ -18,6 +18,15 @@ Usage:
 The mounted directory is available at the same path inside the container
 and on the VM, so docker compose volume mounts resolve correctly.
 
+Claude state (session history, memory, todos, plugins) persists per container
+at ~/.dev-containers/<dev-name>/claude on the host. Static Claude config
+(settings, skills, agents) is owned by home-manager inside the image and is
+updated with `hm-switch` in the container — no image rebuild needed.
+
+Env flags:
+  DEV_DOCKER_SOCK=1   mount the container runtime socket (host-root-equivalent;
+                      off by default). Needed for docker/podman inside the container.
+
 Example:
   dev work ~/repos                       mount all repos
   dev --exec work                        shell in
@@ -36,8 +45,10 @@ elif [ -S "/var/run/docker.sock" ]; then
 else
   PODMAN_SOCKET=""
 fi
+# The container runtime socket is host-root-equivalent, so it is opt-in.
+# Set DEV_DOCKER_SOCK=1 to mount it (needed for docker/podman-in-container).
 SOCKET_MOUNT=""
-if [ -n "$PODMAN_SOCKET" ]; then
+if [ "${DEV_DOCKER_SOCK:-}" = "1" ] && [ -n "$PODMAN_SOCKET" ]; then
   SOCKET_MOUNT="-v $PODMAN_SOCKET:/var/run/docker.sock --security-opt label=disable"
 fi
 
@@ -111,6 +122,20 @@ if [ -n "$HOST_DIR" ]; then
   MOUNT_ENV="-e DEV_MOUNT=${HOST_DIR_ABS}"
 fi
 
+# Per-container Claude state, persisted on the host and isolated per container.
+# Static config (settings.json, skills, agents, ...) is owned by home-manager
+# inside the image; only runtime-generated state lives here. The entrypoint
+# symlinks the state subpaths into ~/.claude at startup.
+CLAUDE_STATE="${HOME}/.dev-containers/${NAME}/claude"
+mkdir -m 700 -p "$CLAUDE_STATE"
+
+# Share the single canonical host credentials file rather than copying it into
+# each container (avoids token sprawl / staleness). Mounted only if it exists.
+CRED_MOUNT=""
+if [ -f "${HOME}/.claude/.credentials.json" ]; then
+  CRED_MOUNT="-v ${HOME}/.claude/.credentials.json:/home/dev/.claude-cred.json"
+fi
+
 ensure_image
 
 echo "Starting container '$NAME'..."
@@ -121,7 +146,8 @@ eval podman run -d \
   $SOCKET_MOUNT \
   $MOUNT_ARGS \
   $MOUNT_ENV \
-  -v "${HOME}/.claude:/home/dev/.claude" \
+  -v "${CLAUDE_STATE}:/home/dev/.claude-state" \
+  $CRED_MOUNT \
   -v "npm-cache-${NAME}:/home/dev/.npm" \
   -e DEV_DETACHED=1 \
   "$IMAGE_NAME"

--- a/nix/hosts/dev-container/default.nix
+++ b/nix/hosts/dev-container/default.nix
@@ -2,13 +2,33 @@
   lib,
   config,
   pkgs,
+  inputs,
   ...
 }:
 
+let
+  # Pinned home-manager from the flake input, so runtime switches use the same
+  # version the image was built with and work without refetching nixpkgs.
+  homeManager = inputs.home-manager.packages.${pkgs.system}.home-manager;
+
+  # Re-apply the home-manager config inside a running container without an image
+  # rebuild. Deliberately does NOT pull — update/review the dotfiles first:
+  #   cd ~/.dotfiles && git fetch && git diff origin/<branch> && git merge --ff-only ...
+  # then run hm-switch. -b backup so a pre-existing real file doesn't error.
+  hm-switch = pkgs.writeShellScriptBin "hm-switch" ''
+    exec ${homeManager}/bin/home-manager switch \
+      --flake "$HOME/.dotfiles/nix#dev@dev-container" -b backup "$@"
+  '';
+in
 {
 
   home.username = "dev";
   home.homeDirectory = "/home/dev";
+
+  home.packages = [
+    homeManager
+    hm-switch
+  ];
 
   devPackages.enable = true;
   opsPackages.enable = true;

--- a/nix/modules/home/content/base.nix
+++ b/nix/modules/home/content/base.nix
@@ -16,6 +16,7 @@
 
     # ./claude
     ".claude/settings.json".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/.dotfiles/files/home/.claude/settings.json";
+    ".claude/statusline-command.sh".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/.dotfiles/files/home/.claude/statusline-command.sh";
     ".claude/CLAUDE.md".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/.dotfiles/files/home/.claude/CLAUDE.md";
     ".claude/keybindings.json".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/.dotfiles/files/home/.claude/keybindings.json";
     ".claude/commands".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/.dotfiles/files/home/.claude/commands";


### PR DESCRIPTION
## Why

Updating Claude config or any home-manager state in a dev container currently requires rebuilding the whole image (`home-manager switch` runs only at build time; `home-manager` isn't even on PATH). And the launcher bind-mounts the entire host `~/.claude` into every container, which shadows home-manager's config symlinks, shares all machines' state into every container, and leaves several config entries (`agents`, `CLAUDE.md`, `commands`, `hooks`, `rules`, `output-styles`) as dangling symlinks.

Designed and reviewed (architect + security) before implementing.

## What changes

**Split static config from runtime state:**
- Static Claude config (settings, skills, agents, commands, hooks, rules, output-styles, CLAUDE.md, statusline) stays home-manager-owned inside the image, now resolving correctly to the container's own `~/.dotfiles` clone (fixes the dangling-symlink bug).
- Runtime state (session history + memory under `projects/`, `todos`, `plugins`, `history.jsonl`) persists per container at `~/.dev-containers/<name>/claude`, bind-mounted and symlinked in by the entrypoint.
- Credentials: share the single canonical host `~/.claude/.credentials.json` (mounted only if present) instead of copying per container — no token sprawl.

**Runtime switch without rebuild:**
- `home-manager` (pinned flake input) is on PATH in `dev-container`, plus an `hm-switch` wrapper that runs `home-manager switch --flake ~/.dotfiles/nix#dev@dev-container -b backup`. Pull/review separately first (deliberate review window).

**Security fixes (from review):**
- Public-repo leak: `settings.json` statusline path was hardcoded to `/Users/quinnherden/...`; now `~/.claude/statusline-command.sh`, with the script tracked in-repo + symlinked via `base.nix`.
- Gate the container runtime socket behind `DEV_DOCKER_SOCK=1` (was always-on; host-root-equivalent).
- `files/home/.claude/.gitignore` denylist so runtime state can never be committed.
- Containerfile `git safe.directory` for the clone under `--userns=keep-id`.

## Note on this branch
`dev` was 38 commits behind `main` and lacked all container infra; it was fast-forwarded to `main` before branching, so the diff here is just these changes.

## After merge (dev → main), to adopt + preserve an in-flight session
Host-side runbook is in the plan; key steps: seed `~/.dev-containers/<name>/claude/projects` from the existing `~/.claude/projects/<key>`, `dev --rebuild`, relaunch with the same cwd, `claude --resume`.

## Verification
See plan. Key checks: static config resolves (no dangling links), `~/.claude` no longer wholesale-mounted (`podman inspect ... Mounts`), `hm-switch` applies config without touching `~/.claude/projects`, state survives `dev --restart`.