### PR TITLE
release: per-container Claude state, runtime hm-switch, anki-decks skill

### DIFF
--- a/container/Containerfile
+++ b/container/Containerfile
@@ -38,6 +38,10 @@ ENV PATH="/home/dev/.npm-global/bin:/home/dev/.local/bin:/home/dev/.nix-profile/
 RUN mkdir -p /home/dev/.config/nix \
     && echo "experimental-features = nix-command flakes" > /home/dev/.config/nix/nix.conf
 
+# Allow git operations on the dotfiles clone at runtime under --userns=keep-id
+# (the runtime uid may differ from the build uid, which git treats as dubious).
+RUN git config --global --add safe.directory /home/dev/.dotfiles
+
 # Pre-fetch flake inputs (big download — cached in this layer if flake.lock unchanged)
 RUN cd /home/dev/.dotfiles/nix && nix flake archive --no-write-lock-file
 

--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -17,6 +17,29 @@ if [ -n "${DEV_MOUNT:-}" ] && [ -d "$DEV_MOUNT" ]; then
   [ ! -e "$HOME/$LINK_NAME" ] && ln -sfn "$DEV_MOUNT" "$HOME/$LINK_NAME"
 fi
 
+# Wire up persistent Claude state.
+# home-manager (at build time) owns the static ~/.claude/* config as symlinks
+# into ~/.dotfiles. Here we link the runtime-generated state subpaths to the
+# mounted per-container state dir so memory, session history, todos and plugins
+# persist on the host. We never touch the static config entries.
+STATE=/home/dev/.claude-state
+if [ -d "$STATE" ]; then
+  mkdir -p "$HOME/.claude"
+  for p in projects todos plugins; do
+    mkdir -p "$STATE/$p"
+    ln -sfn "$STATE/$p" "$HOME/.claude/$p"
+  done
+  [ -e "$STATE/history.jsonl" ] || : > "$STATE/history.jsonl"
+  ln -sfn "$STATE/history.jsonl" "$HOME/.claude/history.jsonl"
+fi
+
+# Share the single canonical host credentials file (mounted by the launcher).
+if [ -e /home/dev/.claude-cred.json ]; then
+  mkdir -p "$HOME/.claude"
+  ln -sfn /home/dev/.claude-cred.json "$HOME/.claude/.credentials.json"
+  chmod 600 /home/dev/.claude-cred.json 2>/dev/null || true
+fi
+
 # Fix git credential helper for container context
 git config --global credential.helper "!$(which gh) auth git-credential"
 

--- a/files/home/.claude/.gitignore
+++ b/files/home/.claude/.gitignore
@@ -1,0 +1,14 @@
+# Never commit runtime-generated Claude state, even if it lands in this subtree.
+# (The repo-root /.claude/ rule does not cover files/home/.claude/.)
+.credentials*
+*.jsonl
+history*
+projects/
+sessions/
+memory/
+todos/
+plugins/
+shell-snapshots/
+file-history/
+paste-cache/
+statsig/

--- a/files/home/.claude/settings.json
+++ b/files/home/.claude/settings.json
@@ -25,7 +25,7 @@
   },
   "statusLine": {
     "type": "command",
-    "command": "bash /Users/quinnherden/.claude/statusline-command.sh"
+    "command": "bash ~/.claude/statusline-command.sh"
   },
   "enabledPlugins": {
     "frontend-design@claude-plugins-official": true,

--- a/files/home/.claude/skills/authoring-anki-decks/SKILL.md
+++ b/files/home/.claude/skills/authoring-anki-decks/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: authoring-anki-decks
+description: Author granular Anki flashcard decks in Markdown and compile them with ankcompiler (the `ankc` CLI). Use when the user wants to turn reference material, notes, or a document into Anki cards / a study deck, or mentions ankcompiler, .apkg, spaced repetition, or memorizing something "cold." Produces atomic, one-fact-per-card decks following the minimum-information principle.
+---
+
+# Authoring Anki decks with ankcompiler
+
+Turn source material into an atomic, high-retention Anki deck and compile it to `.apkg` with `ankc`.
+
+## Tooling
+
+`ankc` is the CLI. Install once if missing: `uv tool install ankcompiler` (or `pip install ankcompiler`). Verify with `ankc --version`.
+
+Decks live in the user's `anki-decks` repo (one subfolder per deck). Generate a blank card stub with `ankc gen chunk` (it emits a fresh 10-char uid).
+
+## Card file format (exact — small mistakes break the build)
+
+```
+---
+deck: Deck Name
+tags:
+  - tag1
+---
+---
+
+Question text ::: Answer text
+
+---
+[^uid]: aB3xK9m2Qr
+
+---
+
+{{c1:: cloze-deleted text}} in a sentence
+
+---
+[^uid]: Zk7pLm4Nv2
+
+.
+```
+
+Hard-won format rules (these caused real build failures):
+
+1. **Double `---` after frontmatter.** The frontmatter's closing `---` must be immediately followed by another `---` (the first card's opening delimiter), back-to-back with no blank line between them.
+2. **Each card is**: `---`, blank line, content, blank line, `---`, then the `[^uid]:` footer. Cards are separated by these `---` delimiters.
+3. **`:::` separates question from answer** in Q&A cards (one line or multi-line). Use `{{c1:: ... }}` for cloze cards (no `:::`).
+4. **Every card needs a unique 10-char alphanumeric uid** in a `[^uid]:` footer. Reusing or omitting one breaks the build. Generate a batch with: `for i in $(seq 1 N); do LC_ALL=C tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 10; echo; done`
+5. **End the file with a blank line then a lone `.`** after the last card's uid. python-frontmatter strips the trailing newline, and without this sentinel the *last* card's uid fails to parse (`No guid found in note meta chunk`).
+6. Optional per-card extra tags: add `[^tag]: tagname` lines under the uid.
+
+## Build and verify
+
+```bash
+mkdir -p dist
+ankc build --deck "Deck Name" --depth 2 --output ./dist
+```
+
+`--depth` must be high enough to reach the deck file in subfolders (default 0 = cwd only). Always verify the card count survived:
+
+```bash
+grep -c '\[\^uid\]:' path/to/deck.md   # uids in source
+# then count notes in the .apkg (unzip, sqlite: select count(*) from notes)
+```
+
+The two numbers must match. `.apkg` output should be gitignored.
+
+## The atomic-card playbook (how to choose what each card tests)
+
+Follow the **minimum information principle**: one retrievable fact per card. A card you can't cleanly grade "right/wrong" is too big — split it. Spaced repetition reschedules a card on its hardest sub-fact, so fat cards waste reviews.
+
+Concrete rules:
+
+- **One fact per card.** If the answer contains "and" joining two facts, split it.
+- **Acronyms get two cards**, one each direction (acronym → expansion, expansion → acronym). ankcompiler has no auto-reverse note type, so write both.
+- **Formulas**: a card for the whole formula, plus separate cards for the hard parts (what's in the numerator, what's excluded, what a threshold signals).
+- **Avoid enumerations.** "Name the 5 components" is unrateable; make one card per component (and optionally one for the count).
+- **No yes/no questions** (50% guess rate, no recall). Rewrite as "what / which / how."
+- **Disambiguate confusable items** with explicit contrast cards (e.g. "NRR vs GRR — key difference?"). Interference between similar items is the main cause of forgetting in a dense deck.
+- **Keep answers short** (≤ ~15 words). Specific, unambiguous questions; the back is a complete standalone answer.
+- **No source attribution or extra context on the front** unless that's the fact being tested.
+
+For a definitional reference (metrics, terms, concepts), a good repeatable per-item card set is: acronym↔expansion (2 cards), one-sentence definition, formula, key exclusion/boundary, why-it-matters/threshold, benchmark, and a disambiguation card for any close cousin. Don't force all of these — generate the ones that carry real, distinct knowledge. Don't try to stuff every sentence of the source into cards; capture what must be known cold.
+
+## Workflow summary
+
+1. Read the source material; list the atomic facts worth knowing cold.
+2. Decide deck name + tags. Create `anki-decks/<deck-slug>/<deck-slug>.md`.
+3. Generate enough uids up front.
+4. Write cards following the format rules and the atomic playbook.
+5. `ankc build`, then verify source uid count == apkg note count.
+6. Commit the `.md` (gitignore `dist/`/`*.apkg`). Tell the user to `ankc build` and import the `.apkg` into Anki (File → Import).

--- a/files/home/.claude/statusline-command.sh
+++ b/files/home/.claude/statusline-command.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+input=$(cat)
+
+user=$(whoami)
+host=$(hostname -s)
+dir=$(echo "$input" | jq -r '.workspace.current_dir')
+model=$(echo "$input" | jq -r '.model.display_name')
+used=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
+
+git_branch=""
+if git -C "$dir" rev-parse --git-dir > /dev/null 2>&1; then
+  branch=$(git -C "$dir" symbolic-ref --short HEAD 2>/dev/null || git -C "$dir" rev-parse --short HEAD 2>/dev/null)
+  [ -n "$branch" ] && git_branch=" [$branch]"
+fi
+
+ctx=""
+[ -n "$used" ] && ctx=" ctx:$(printf '%.0f' "$used")%"
+
+printf "%s@%s %s%s | %s%s\n" "$user" "$host" "$dir" "$git_branch" "$model" "$ctx"

--- a/files/scripts/dev
+++ b/files/scripts/dev
@@ -18,6 +18,15 @@ Usage:
 The mounted directory is available at the same path inside the container
 and on the VM, so docker compose volume mounts resolve correctly.
 
+Claude state (session history, memory, todos, plugins) persists per container
+at ~/.dev-containers/<dev-name>/claude on the host. Static Claude config
+(settings, skills, agents) is owned by home-manager inside the image and is
+updated with `hm-switch` in the container — no image rebuild needed.
+
+Env flags:
+  DEV_DOCKER_SOCK=1   mount the container runtime socket (host-root-equivalent;
+                      off by default). Needed for docker/podman inside the container.
+
 Example:
   dev work ~/repos                       mount all repos
   dev --exec work                        shell in
@@ -36,8 +45,10 @@ elif [ -S "/var/run/docker.sock" ]; then
 else
   PODMAN_SOCKET=""
 fi
+# The container runtime socket is host-root-equivalent, so it is opt-in.
+# Set DEV_DOCKER_SOCK=1 to mount it (needed for docker/podman-in-container).
 SOCKET_MOUNT=""
-if [ -n "$PODMAN_SOCKET" ]; then
+if [ "${DEV_DOCKER_SOCK:-}" = "1" ] && [ -n "$PODMAN_SOCKET" ]; then
   SOCKET_MOUNT="-v $PODMAN_SOCKET:/var/run/docker.sock --security-opt label=disable"
 fi
 
@@ -111,6 +122,20 @@ if [ -n "$HOST_DIR" ]; then
   MOUNT_ENV="-e DEV_MOUNT=${HOST_DIR_ABS}"
 fi
 
+# Per-container Claude state, persisted on the host and isolated per container.
+# Static config (settings.json, skills, agents, ...) is owned by home-manager
+# inside the image; only runtime-generated state lives here. The entrypoint
+# symlinks the state subpaths into ~/.claude at startup.
+CLAUDE_STATE="${HOME}/.dev-containers/${NAME}/claude"
+mkdir -m 700 -p "$CLAUDE_STATE"
+
+# Share the single canonical host credentials file rather than copying it into
+# each container (avoids token sprawl / staleness). Mounted only if it exists.
+CRED_MOUNT=""
+if [ -f "${HOME}/.claude/.credentials.json" ]; then
+  CRED_MOUNT="-v ${HOME}/.claude/.credentials.json:/home/dev/.claude-cred.json"
+fi
+
 ensure_image
 
 echo "Starting container '$NAME'..."
@@ -121,7 +146,8 @@ eval podman run -d \
   $SOCKET_MOUNT \
   $MOUNT_ARGS \
   $MOUNT_ENV \
-  -v "${HOME}/.claude:/home/dev/.claude" \
+  -v "${CLAUDE_STATE}:/home/dev/.claude-state" \
+  $CRED_MOUNT \
   -v "npm-cache-${NAME}:/home/dev/.npm" \
   -e DEV_DETACHED=1 \
   "$IMAGE_NAME"

--- a/nix/hosts/dev-container/default.nix
+++ b/nix/hosts/dev-container/default.nix
@@ -2,13 +2,33 @@
   lib,
   config,
   pkgs,
+  inputs,
   ...
 }:
 
+let
+  # Pinned home-manager from the flake input, so runtime switches use the same
+  # version the image was built with and work without refetching nixpkgs.
+  homeManager = inputs.home-manager.packages.${pkgs.system}.home-manager;
+
+  # Re-apply the home-manager config inside a running container without an image
+  # rebuild. Deliberately does NOT pull — update/review the dotfiles first:
+  #   cd ~/.dotfiles && git fetch && git diff origin/<branch> && git merge --ff-only ...
+  # then run hm-switch. -b backup so a pre-existing real file doesn't error.
+  hm-switch = pkgs.writeShellScriptBin "hm-switch" ''
+    exec ${homeManager}/bin/home-manager switch \
+      --flake "$HOME/.dotfiles/nix#dev@dev-container" -b backup "$@"
+  '';
+in
 {
 
   home.username = "dev";
   home.homeDirectory = "/home/dev";
+
+  home.packages = [
+    homeManager
+    hm-switch
+  ];
 
   devPackages.enable = true;
   opsPackages.enable = true;

--- a/nix/modules/home/content/base.nix
+++ b/nix/modules/home/content/base.nix
@@ -16,6 +16,7 @@
 
     # ./claude
     ".claude/settings.json".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/.dotfiles/files/home/.claude/settings.json";
+    ".claude/statusline-command.sh".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/.dotfiles/files/home/.claude/statusline-command.sh";
     ".claude/CLAUDE.md".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/.dotfiles/files/home/.claude/CLAUDE.md";
     ".claude/keybindings.json".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/.dotfiles/files/home/.claude/keybindings.json";
     ".claude/commands".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/.dotfiles/files/home/.claude/commands";


### PR DESCRIPTION
Promotes to main:
- **#100** — per-container Claude state, runtime `home-manager switch` (`hm-switch`), config-leak fix, socket gating, state denylist.
- **#99** — `authoring-anki-decks` Claude skill.

Both reviewed and merged into dev. See the individual PRs for detail.