### PR TITLE
fix: container build gitconfig collision

### DIFF
--- a/container/Containerfile
+++ b/container/Containerfile
@@ -38,10 +38,6 @@ ENV PATH="/home/dev/.npm-global/bin:/home/dev/.local/bin:/home/dev/.nix-profile/
 RUN mkdir -p /home/dev/.config/nix \
     && echo "experimental-features = nix-command flakes" > /home/dev/.config/nix/nix.conf
 
-# Allow git operations on the dotfiles clone at runtime under --userns=keep-id
-# (the runtime uid may differ from the build uid, which git treats as dubious).
-RUN git config --global --add safe.directory /home/dev/.dotfiles
-
 # Pre-fetch flake inputs (big download — cached in this layer if flake.lock unchanged)
 RUN cd /home/dev/.dotfiles/nix && nix flake archive --no-write-lock-file
 

--- a/files/home/.gitconfig
+++ b/files/home/.gitconfig
@@ -4,6 +4,11 @@
 	email = 55929299+QuinnHerden@users.noreply.github.com
 [init]
 	defaultBranch = main
+[safe]
+	# Allow git/nix-flake operations on the dotfiles clone inside dev containers
+	# (built as one uid, run under --userns=keep-id). Harmless where the path
+	# does not exist.
+	directory = /home/dev/.dotfiles
 [color]
 	ui = auto
 [pull]


### PR DESCRIPTION
## Problem

`dev --rebuild` fails at the build-time `home-manager switch` with:

> Existing file '/home/dev/.gitconfig' is in the way of '...-home-manager-files/.gitconfig'

Root cause: the `RUN git config --global --add safe.directory /home/dev/.dotfiles` line (added in #100) creates a real `~/.gitconfig` *before* the home-manager switch, which then refuses to lay down the `.gitconfig` symlink it manages. Setting it after the switch wouldn't work either, since `~/.gitconfig` becomes an out-of-store symlink to the tracked `files/home/.gitconfig`.

## Fix

- Remove the `RUN git config ...` line from the Containerfile.
- Add `[safe] directory = /home/dev/.dotfiles` to the tracked `files/home/.gitconfig`, so home-manager carries it in via the existing symlink with no build collision. Harmless on hosts where that path doesn't exist.

(With `--userns=keep-id` the clone uid matches the runtime uid, so this is mostly a safety net for nix-flake git operations like `hm-switch`.)

Unblocks the rebuild.