### PR TITLE
release: fix container build gitconfig collision

### DIFF
--- a/container/Containerfile
+++ b/container/Containerfile
@@ -38,10 +38,6 @@ ENV PATH="/home/dev/.npm-global/bin:/home/dev/.local/bin:/home/dev/.nix-profile/
 RUN mkdir -p /home/dev/.config/nix \
     && echo "experimental-features = nix-command flakes" > /home/dev/.config/nix/nix.conf
 
-# Allow git operations on the dotfiles clone at runtime under --userns=keep-id
-# (the runtime uid may differ from the build uid, which git treats as dubious).
-RUN git config --global --add safe.directory /home/dev/.dotfiles
-
 # Pre-fetch flake inputs (big download — cached in this layer if flake.lock unchanged)
 RUN cd /home/dev/.dotfiles/nix && nix flake archive --no-write-lock-file
 

--- a/files/home/.gitconfig
+++ b/files/home/.gitconfig
@@ -4,6 +4,11 @@
 	email = 55929299+QuinnHerden@users.noreply.github.com
 [init]
 	defaultBranch = main
+[safe]
+	# Allow git/nix-flake operations on the dotfiles clone inside dev containers
+	# (built as one uid, run under --userns=keep-id). Harmless where the path
+	# does not exist.
+	directory = /home/dev/.dotfiles
 [color]
 	ui = auto
 [pull]


### PR DESCRIPTION
Hotfix for the build break introduced by #100 — sets git safe.directory via the tracked gitconfig instead of a RUN that collided with home-manager. See #102.