### PR TITLE
Persist Claude + gh/git auth across container recreation

### DIFF
--- a/container/Containerfile
+++ b/container/Containerfile
@@ -31,6 +31,7 @@ RUN git clone --branch ${DOTFILES_BRANCH} ${DOTFILES_REPO} /home/dev/.dotfiles
 ENV PATH="/home/dev/.npm-global/bin:/home/dev/.local/bin:/home/dev/.nix-profile/bin:${PATH}" \
     NPM_CONFIG_PREFIX=/home/dev/.npm-global \
     CONTAINER_HOST="unix:///var/run/docker.sock" \
+    CLAUDE_CONFIG_DIR=/home/dev/.dev-state/claude \
     USER=dev \
     HOME=/home/dev
 

--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -17,33 +17,42 @@ if [ -n "${DEV_MOUNT:-}" ] && [ -d "$DEV_MOUNT" ]; then
   [ ! -e "$HOME/$LINK_NAME" ] && ln -sfn "$DEV_MOUNT" "$HOME/$LINK_NAME"
 fi
 
-# Wire up persistent Claude state.
-# home-manager (at build time) owns the static ~/.claude/* config as symlinks
-# into ~/.dotfiles. Here we link the runtime-generated state subpaths to the
-# mounted per-container state dir so memory, session history, todos and plugins
-# persist on the host. We never touch the static config entries.
-STATE=/home/dev/.claude-state
-if [ -d "$STATE" ]; then
-  mkdir -p "$HOME/.claude"
-  for p in projects todos plugins; do
-    mkdir -p "$STATE/$p"
-    ln -sfn "$STATE/$p" "$HOME/.claude/$p"
+# Wire up Claude config + state.
+# CLAUDE_CONFIG_DIR (set in the image) points Claude at the per-container
+# persistent mount, so everything it writes (credentials, .claude.json,
+# sessions, projects, todos, history) survives container recreation and you
+# authenticate once. This relies on CLAUDE_CONFIG_DIR relocating the whole
+# config dir (verified empirically; the scope is only partly documented
+# upstream). The static config is symlinked in from the dotfiles clone, so
+# editing ~/.dotfiles is live; new files are picked up on the next start.
+# We re-establish each link from scratch so a stale real file/dir at the target
+# (e.g. one Claude wrote, or a pre-existing dir) can't shadow the symlink.
+CCDIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+mkdir -p "$CCDIR"; chmod 700 "$CCDIR" 2>/dev/null || true
+DOT=/home/dev/.dotfiles/files/home/.claude
+if [ -d "$DOT" ]; then
+  for f in "$DOT"/*; do
+    [ -e "$f" ] || continue
+    name=$(basename "$f")
+    rm -rf "$CCDIR/$name"
+    ln -sfn "$f" "$CCDIR/$name"
   done
-  [ -e "$STATE/history.jsonl" ] || : > "$STATE/history.jsonl"
-  ln -sfn "$STATE/history.jsonl" "$HOME/.claude/history.jsonl"
 fi
 
-# Share the single canonical host credentials file (mounted by the launcher).
-if [ -e /home/dev/.claude-cred.json ]; then
-  mkdir -p "$HOME/.claude"
-  ln -sfn /home/dev/.claude-cred.json "$HOME/.claude/.credentials.json"
-  chmod 600 /home/dev/.claude-cred.json 2>/dev/null || true
-fi
-
-# Share global (user-level) Claude memory across all containers.
+# Global (user-level) Claude memory is shared across all containers (mounted by
+# the launcher), not per-container like the rest of the config dir.
 if [ -d /home/dev/.claude-memory ]; then
-  mkdir -p "$HOME/.claude"
-  ln -sfn /home/dev/.claude-memory "$HOME/.claude/memory"
+  rm -rf "$CCDIR/memory"
+  ln -sfn /home/dev/.claude-memory "$CCDIR/memory"
+fi
+
+# Persist gh CLI auth in the per-container state so it survives recreation. git
+# uses `gh auth git-credential`, so this fixes git auth too.
+if [ -d /home/dev/.dev-state ]; then
+  mkdir -p /home/dev/.dev-state/config/gh "$HOME/.config"
+  chmod 700 /home/dev/.dev-state/config/gh 2>/dev/null || true
+  rm -rf "$HOME/.config/gh"
+  ln -sfn /home/dev/.dev-state/config/gh "$HOME/.config/gh"
 fi
 
 # Fix git credential helper for container context

--- a/files/scripts/dev
+++ b/files/scripts/dev
@@ -18,12 +18,13 @@ Usage:
 The mounted directory is available at the same path inside the container
 and on the VM, so docker compose volume mounts resolve correctly.
 
-Claude per-container state (session history, todos, plugins) persists at
-~/.dev-containers/<dev-name>/claude on the host. Global memory and credentials
-are shared from the single host ~/.claude/{memory,.credentials.json} across all
-containers. Static Claude config (settings, skills, agents) is owned by
-home-manager inside the image and is updated with `hm-switch` in the
-container — no image rebuild needed.
+Per-container state (Claude credentials/sessions/projects/history and gh/git
+auth) persists at ~/.dev-containers/<dev-name> on the host, so you authenticate
+once. It survives --stop/--restart by design; delete that dir to fully reset a
+container. Global Claude memory is shared from ~/.claude/memory across all
+containers. Static Claude config (settings, skills, agents) lives in the
+dotfiles clone and is symlinked into the config dir at container start, so
+editing ~/.dotfiles is live; restart the container to pick up newly added files.
 
 Env flags:
   DEV_DOCKER_SOCK=1   mount the container runtime socket (host-root-equivalent;
@@ -124,19 +125,13 @@ if [ -n "$HOST_DIR" ]; then
   MOUNT_ENV="-e DEV_MOUNT=${HOST_DIR_ABS}"
 fi
 
-# Per-container Claude state, persisted on the host and isolated per container.
-# Static config (settings.json, skills, agents, ...) is owned by home-manager
-# inside the image; only runtime-generated state lives here. The entrypoint
-# symlinks the state subpaths into ~/.claude at startup.
-CLAUDE_STATE="${HOME}/.dev-containers/${NAME}/claude"
-mkdir -m 700 -p "$CLAUDE_STATE"
-
-# Share the single canonical host credentials file rather than copying it into
-# each container (avoids token sprawl / staleness). Mounted only if it exists.
-CRED_MOUNT=""
-if [ -f "${HOME}/.claude/.credentials.json" ]; then
-  CRED_MOUNT="-v ${HOME}/.claude/.credentials.json:/home/dev/.claude-cred.json"
-fi
+# Per-container persistent state, isolated per container and kept on the host.
+# Mounted at /home/dev/.dev-state and organized by tool (claude/, config/gh).
+# CLAUDE_CONFIG_DIR (set in the image) points Claude at .dev-state/claude, so
+# credentials and session state persist; the entrypoint persists gh auth here
+# too. The entrypoint symlinks the static config in from the dotfiles clone.
+DEV_STATE="${HOME}/.dev-containers/${NAME}"
+mkdir -m 700 -p "$DEV_STATE"
 
 # Global Claude memory is user-level (facts about you, projects, preferences),
 # so share the single canonical host dir across all containers rather than
@@ -153,9 +148,8 @@ eval podman run -d \
   $SOCKET_MOUNT \
   $MOUNT_ARGS \
   $MOUNT_ENV \
-  -v "${CLAUDE_STATE}:/home/dev/.claude-state" \
+  -v "${DEV_STATE}:/home/dev/.dev-state" \
   -v "${HOME}/.claude/memory:/home/dev/.claude-memory" \
-  $CRED_MOUNT \
   -v "npm-cache-${NAME}:/home/dev/.npm" \
   -e DEV_DETACHED=1 \
   "$IMAGE_NAME"

--- a/nix/modules/home/content/base.nix
+++ b/nix/modules/home/content/base.nix
@@ -15,6 +15,10 @@
     ".tmux.conf".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/.dotfiles/files/home/.tmux.conf";
 
     # ./claude
+    # On the laptop these manage ~/.claude directly. In dev containers Claude is
+    # pointed at CLAUDE_CONFIG_DIR instead (see container/entrypoint.sh), which
+    # symlinks these same dotfiles sources into the persistent per-container
+    # config dir; the ~/.claude entries below are inert there. Keep both in sync.
     ".claude/settings.json".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/.dotfiles/files/home/.claude/settings.json";
     ".claude/statusline-command.sh".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/.dotfiles/files/home/.claude/statusline-command.sh";
     ".claude/CLAUDE.md".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/.dotfiles/files/home/.claude/CLAUDE.md";


### PR DESCRIPTION
Promotes #106. Makes Claude and gh/git auth survive container recreation via CLAUDE_CONFIG_DIR on a per-container persistent mount + persisted ~/.config/gh.