### PR TITLE
fix: use PATH-relative gh in gitconfig credential helper

### DIFF
--- a/files/home/.gitconfig
+++ b/files/home/.gitconfig
@@ -17,7 +17,7 @@
 	excludesfile = ~/.gitignore_global
 [credential "https://github.com"]
 	helper = 
-	helper = !/run/current-system/sw/bin/gh auth git-credential
+	helper = !gh auth git-credential
 [credential "https://gist.github.com"]
 	helper = 
-	helper = !/run/current-system/sw/bin/gh auth git-credential
+	helper = !gh auth git-credential


### PR DESCRIPTION
Replaces the hardcoded `/run/current-system/sw/bin/gh` (NixOS-specific, absent in dev containers) with `!gh` so the credential helper resolves from PATH and works in both environments. Reviews flagged PATH-shadowing as borderline low — acceptable on a single-user Nix-managed machine.