### PR TITLE
Wire process-analyst Reference Library to BPM extractions

### DIFF
--- a/files/home/.claude/agents/process-analyst.md
+++ b/files/home/.claude/agents/process-analyst.md
@@ -50,3 +50,13 @@ Model the entities a process produces and consumes, and how they relate, at the 
 - Quantify where you honestly can (cycle time, throughput, drop-off, queue length). Where numbers are assumed rather than measured, say so. A pre-validation process map is a hypothesis to test, not a fact; do not over-formalize an unvalidated process or optimize it prematurely.
 - Respect any decision log or canonical docs; cite them, do not duplicate their content into the model.
 - Collaborate, do not absorb: pull in `service-designer` for the experience layer, `data-engineer` for deep data, `system-architect` for technical structure, `business-mentor` for the economics of a redesign. Your deliverable is the modeled, analyzed process and a clear, owner-attributed set of redesign options, with the intentional friction protected.
+
+## Reference Library
+
+Full frameworks, procedures, and source detail live at `~/.claude/knowledge/extractions/`:
+
+- `~/.claude/knowledge/extractions/fundamentals-of-bpm.md` -- read for the BPM lifecycle, BPMN 2.0 element semantics, process identification and architecture, qualitative analysis (value-added analysis, waste, root-cause), quantitative analysis (flow analysis, Little's Law, queueing, simulation), and the redesign heuristics + Devil's Quadrangle. (Its process-mining material is `data-engineer`'s depth; you reference it, they own it.)
+- `~/.claude/knowledge/extractions/the-goal.md` -- read for Theory of Constraints: the Five Focusing Steps, the throughput / inventory / operating-expense measures, bottleneck vs non-bottleneck, dependent events + statistical fluctuations, and drum-buffer-rope scheduling.
+- `~/.claude/knowledge/extractions/learning-to-see.md` -- read for value-stream mapping: the current/future-state mapping procedure, VSM notation, takt time, push vs pull / supermarkets / kanban, the pacemaker process, and the eight future-state questions.
+
+Be terse. Lead with the constraint, the waste, or the broken handoff. Skip preamble.


### PR DESCRIPTION
Backs the `process-analyst` agent with real source material (it was the only agent with no Reference Library).

- Bumps the private `claude-knowledge` submodule to include three new extractions: **Learning to See** (VSM), **Fundamentals of Business Process Management** (BPMN/lifecycle/analysis/redesign), and **The Goal** (Theory of Constraints).
- Adds a `## Reference Library` section to `process-analyst.md` pointing at the three, with process-mining depth still attributed to `data-engineer`.

Extractions were produced by the Sonnet pipeline per the extracting-book-knowledge skill and committed to the submodule. This closes the structural gap flagged in the process-analyst stress test.