### PR TITLE
Update CLAUDE.md (agent rename + delegation/memory guidance)

### DIFF
--- a/files/home/.claude/CLAUDE.md
+++ b/files/home/.claude/CLAUDE.md
@@ -31,9 +31,15 @@ Output markdown when formatting helps. Match the structure of the content — do
 
 ## Agents
 
-After writing or modifying code, before making any git commit, invoke all three agents in parallel: `code-reviewer`, `sw-architect`, and `security-analyst`. Do not commit until all three have run and any critical or high findings are resolved.
+After writing or modifying code, before making any git commit, invoke all three agents in parallel: `code-reviewer`, `system-architect`, and `security-analyst`. Do not commit until all three have run and any critical or high findings are resolved.
 
-When reviewing a plan (formal plan-mode or a system design discussion), invoke `sw-architect`, `ux-designer`, and `security-analyst` in parallel before finalizing the approach.
+When reviewing a plan (formal plan-mode or a system design discussion), invoke `system-architect`, `ux-designer`, and `security-analyst` in parallel before finalizing the approach.
+
+Delegate for context isolation, not speed. A subagent runs in its own context window and returns only a distilled result; the main thread blocks until it finishes. Delegate read-heavy, search-heavy, or self-contained specialist work so it burns the child's window, not the main one. Do it inline when the task is short, tightly iterative, needs active course-correction, or is fidelity-critical. For genuinely non-blocking work, use a background shell command, not a subagent.
+
+## Context & Memory
+
+Treat the context window as finite memory and auto-compaction as lossy eviction: compacted detail is gone, not recoverable. Keep the active working set small. Before context can be evicted, persist anything that must survive (decisions, in-flight intent, task state) to memory files or the todo list. Treat compaction as a crash boundary you recover from, not a pause.
 
 ## What to Avoid
 


### PR DESCRIPTION
Renames sw-architect -> system-architect (matching the agent roster), and adds two guidance paragraphs: delegate for context isolation (not speed), and treat context/auto-compaction as a lossy crash boundary (persist state before eviction). No personal data; this file is already tracked.