### PR TITLE
Fix NixOS home path (/Users -> /home) — fixes the VM boot test

### DIFF
--- a/nix/modules/system/nixos/users/quinnherdenUser.nix
+++ b/nix/modules/system/nixos/users/quinnherdenUser.nix
@@ -16,7 +16,7 @@
   config = lib.mkIf config.quinnherdenUser.enable {
     users.users."quinnherden" = {
       name = "quinnherden";
-      home = "/Users/quinnherden";
+      home = "/home/quinnherden";
 
       isNormalUser = true;
       extraGroups = [


### PR DESCRIPTION
The post-merge `nixos-vm-test` job failed on `test -d /home/quinnherden`.

**Root cause:** `nix/modules/system/nixos/users/quinnherdenUser.nix` set `home = "/Users/quinnherden"` — a macOS path copy-pasted from the darwin host when the module was abstracted out. On NixOS the home is never created there, so both `nix-box` and `nix-dots` had the wrong home directory. The VM boot test caught a genuine bug a build never could.

**Fix:** `home = "/home/quinnherden"`. This is a real-config fix (not test-only) because both NixOS hosts consume this module; a test-only override would have masked the bug.

Validated via `gh workflow run` on this branch: the `nixos vm boot test` job plus all five build jobs pass green (run 27661681469).