### PR TITLE
README: orientation for readers + MIT LICENSE (#133)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Quinn Herden
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,36 @@
 # .dotfiles
 
-A curated collection of personal system configurations.
-Enabling a seamless experience across host environments.
+Personal Nix dotfiles: home-manager, nix-darwin, and NixOS across my Mac, my NixOS workstations, and a Podman dev container, plus a Claude Code setup (custom agents, skills, and a knowledge base).
+
+> **This is my personal setup, not a template.** Hostnames, hosts, and secrets are mine, and the `knowledge/` submodule is private. Fork and adapt at your own pace; don't expect it to run clean on your machine. It is meant to be *read* for patterns, not cloned wholesale.
+
+## What's in here
+
+| Path | What it is |
+|------|------------|
+| `nix/flake.nix` | The host matrix. Every machine (darwin / NixOS / home-manager) is an output here. |
+| `nix/hosts/` | Per-machine config: `dev-container`, `mac-papi`, `nix-box`, `nix-dots`, `kali-bug`. |
+| `nix/modules/` | Shared building blocks (`home`, `system`, `packages`). Package data is centralized in `packages/` and consumed by thin per-platform wrappers. |
+| `files/config/` | App dotfiles: nvim, i3, rofi, qutebrowser, karabiner. |
+| `files/home/` | Home-level files, including `.claude/` (the Claude Code setup). |
+| `files/scripts/` | Bootstrap (`.init`, `.switch`, `.update`) and the `dev` Podman wrapper. |
+| `container/` | The dev-container image (Containerfile and entrypoint). |
+| `.github/workflows/ci.yml` | CI: flake eval, lint, per-host builds, and a NixOS VM boot test. |
+
+## Start here (reading, not installing)
+
+1. `nix/flake.nix`, the host matrix. See how each machine maps to a set of modules.
+2. `nix/hosts/dev-container/`, the smallest and most self-contained host. The best first example.
+3. `files/scripts/dev`, the Podman dev-container wrapper.
+4. `files/home/.claude/`, the Claude Code setup (below).
+
+## The Claude Code setup
+
+Probably the most reusable part of this repo. `files/home/.claude/` holds:
+
+- **agents/**: focused specialist subagents (system-architect, security-analyst, code-reviewer, data-engineer, cloud-platform, process-analyst, plus GTM, brand, and UX specialists). Each carries compressed named frameworks inline and a `Reference Library` pointer to the deeper source material.
+- **skills/**: repeatable procedures (extracting book knowledge into the knowledge base, stress-testing an agent, and more).
+- **knowledge/**: a 20/80 extraction library that backs the agents. It is a *private* git submodule (the extractions distill copyrighted source material), so it will not populate on a public clone. That is intentional, not a broken repo.
 
 ## Prerequisites
 
@@ -55,7 +84,7 @@ Enabling a seamless experience across host environments.
 Set your hostname to match the host config you want to sync to.
 
 - **NixOS / MacOS:** `sudo hostname {hostname}`
-- **Generic Linux:** already done in prerequisites — `.switch` uses `$(whoami)@$(hostname)` to resolve your `homeConfigurations` entry
+- **Generic Linux:** already done in prerequisites; `.switch` uses `$(whoami)@$(hostname)` to resolve your `homeConfigurations` entry
 
 ### Configure System
 
@@ -120,3 +149,6 @@ dev branch-b ~/repos
 
 - [Configurations](manual-configurations.md)
 
+## License
+
+[MIT](LICENSE). This is a personal setup shared as a readable reference; use anything you find useful, no warranty.


### PR DESCRIPTION
Implements #133 up to (not including) the over-engineering items, which are split to #144.

- **README lead block**: one-line "what is this", plus a **"this is my personal setup, not a template"** disclaimer (hostnames/secrets are mine, `knowledge/` is private, read it for patterns rather than cloning).
- **Repo-map table**: each top-level path to a one-line purpose.
- **"Start here" reading path**: `nix/flake.nix` -> `nix/hosts/dev-container/` -> `dev` script -> `.claude/`.
- **Claude Code section**: highlights agents/skills/knowledge as the most reusable part, and explains the private `knowledge/` submodule won't populate on a public clone (intentional, not broken).
- **MIT LICENSE** added.

Closes #133. Deferred over-engineering tracked in #144.