### PR TITLE
Route writing through writer agents; technical-writer pass on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,69 +26,71 @@ Personal Nix dotfiles: home-manager, nix-darwin, and NixOS across my Mac, my Nix
 
 ## The Claude Code setup
 
-Probably the most reusable part of this repo. `files/home/.claude/` holds:
+Likely the most reusable part of this repo. `files/home/.claude/` holds:
 
 - **agents/**: focused specialist subagents (system-architect, security-analyst, code-reviewer, data-engineer, cloud-platform, process-analyst, plus GTM, brand, and UX specialists). Each carries compressed named frameworks inline and a `Reference Library` pointer to the deeper source material.
 - **skills/**: repeatable procedures (extracting book knowledge into the knowledge base, stress-testing an agent, and more).
-- **knowledge/**: a 20/80 extraction library that backs the agents. It is a *private* git submodule (the extractions distill copyrighted source material), so it will not populate on a public clone. That is intentional, not a broken repo.
+- **knowledge/**: a 20/80 extraction library that backs the agents. It is a *private* git submodule, since the extractions distill copyrighted source material, so it will not populate on a public clone. That is intentional, not a broken repo.
 
-## Prerequisites
+## Install (reinstalling on a new machine)
 
-### On MacOS
+This is the runbook for setting up a machine, written for me. The host config is keyed by hostname, so the hostname must match an entry before `.switch` will resolve.
 
-#### Install Nix
+### 1. Prerequisites
 
-- `curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install`
+On macOS, install Nix:
 
-### On Generic Linux (non-NixOS)
+```bash
+curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
+```
 
-#### Set hostname to match your host config
+On NixOS, get online and make git available:
 
-- `sudo hostname {hostname}` (e.g. `kali-bug`)
+```bash
+nmcli d wifi list
+nmcli d wifi connect {ssid} --ask
+nix-shell -p git
+```
 
-#### Ensure curl is available
+On generic Linux (non-NixOS), set the hostname and make sure curl is present:
 
-- `sudo apt install curl` or equivalent
+```bash
+sudo hostname {hostname}        # e.g. kali-bug
+sudo apt install curl           # or your distro's equivalent
+```
 
-### On All
+### 2. Clone
 
-#### Connect to the Internet
+```bash
+cd ~/
+git clone https://github.com/QuinnHerden/.dotfiles.git
+```
 
-##### NixOS
+### 3. Init
 
-- `nmcli d wifi list`
-- `nmcli d wifi connect {ssid} --ask`
+Run the bootstrap script. It is not idempotent in one pass; run it repeatedly until it exits 0.
 
-#### Ensure git is in your path
+```bash
+sh ~/.dotfiles/files/scripts/.init
+```
 
-##### NixOS
+### 4. Set hostname
 
-- `nix-shell -p git`
+The hostname selects which host config to sync to.
 
-## Installation
+```bash
+sudo hostname {hostname}        # NixOS / macOS
+```
 
-### Navigate Home
+On generic Linux this is already done from step 1. There, `.switch` resolves the `homeConfigurations` entry from `$(whoami)@$(hostname)`.
 
-- `cd ~/`
+### 5. Switch
 
-### Clone Repo
+Apply the config:
 
-- `git clone https://github.com/QuinnHerden/.dotfiles.git`
-
-### Init System
-
-- run `sh ~/.dotfiles/files/scripts/.init` repeatedly until you receive a successful exit status.
-
-### Set hostname
-
-Set your hostname to match the host config you want to sync to.
-
-- **NixOS / MacOS:** `sudo hostname {hostname}`
-- **Generic Linux:** already done in prerequisites; `.switch` uses `$(whoami)@$(hostname)` to resolve your `homeConfigurations` entry
-
-### Configure System
-
-- run `sh ~/.dotfiles/files/scripts/.switch` to configure your system.
+```bash
+sh ~/.dotfiles/files/scripts/.switch
+```
 
 ## Dev Containers
 
@@ -129,7 +131,7 @@ dev --rebuild                # rebuild the image (after dotfiles changes)
 
 The mounted directory is available at the same host path inside the container, so `docker compose` volume mounts resolve correctly on the VM.
 
-The first start takes ~15 seconds to install Claude Code via npm. Subsequent starts are near-instant (npm cache persists in a named volume).
+The first start installs Claude Code via npm and takes a few seconds. Subsequent starts are near-instant, since the npm cache persists in a named volume.
 
 ### Parallel development
 

--- a/files/home/.claude/CLAUDE.md
+++ b/files/home/.claude/CLAUDE.md
@@ -33,7 +33,9 @@ Output markdown when formatting helps. Match the structure of the content — do
 
 After writing or modifying code, before making any git commit, invoke all three agents in parallel: `code-reviewer`, `system-architect`, and `security-analyst`. Do not commit until all three have run and any critical or high findings are resolved.
 
-When reviewing a plan (formal plan-mode or a system design discussion), consult the specialist agents most relevant to it, in parallel, before finalizing the approach. Pick whichever would add the most signal for this particular plan (architecture, security, UX, data, CRO, process, etc.) rather than a fixed roster — and skip the review only when the plan is trivial.
+When reviewing a plan (formal plan-mode or a system design discussion), consult the specialist agents most relevant to it, in parallel, before finalizing the approach. Pick whichever would add the most signal for this particular plan (architecture, security, UX, data, CRO, process, etc.) rather than a fixed roster. Skip the review only when the plan is trivial.
+
+Run substantial writing through the appropriate writer agent before finalizing: `technical-writer` for documentation, READMEs, guides, and GitHub issue/PR prose; `copy-writer` for marketing, persuasion, and customer-facing copy. Skip the pass only for throwaway one-liners.
 
 Delegate for context isolation, not speed. A subagent runs in its own context window and returns only a distilled result; the main thread blocks until it finishes. Delegate read-heavy, search-heavy, or self-contained specialist work so it burns the child's window, not the main one. Do it inline when the task is short, tightly iterative, needs active course-correction, or is fidelity-critical. For genuinely non-blocking work, use a background shell command, not a subagent.
 


### PR DESCRIPTION
Establishes a standing rule and applies it to the README that just merged.

- **CLAUDE.md (global):** substantial writing now routes to the appropriate writer agent before finalizing — `technical-writer` for docs/READMEs/guides/issue+PR prose, `copy-writer` for marketing/persuasion/customer-facing copy. Skip only for throwaway one-liners. (Also removed an em dash from the plan-review line.)
- **README:** `technical-writer` revision of the version merged in #145 — install steps regrouped into one numbered flow, a curse-of-knowledge gap on `.init` (why you run it repeatedly) fixed, prose tightened to one-idea-per-sentence, and the unverifiable "~15 seconds" first-start claim softened to "a few seconds."

Not merging until you say so.