### PR TITLE
Repo polish: badges, host diagram, PR + issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,26 @@
+---
+name: Bug
+about: Something is broken or behaving wrong.
+title: ""
+labels: "bug"
+---
+
+## Summary
+
+<!-- What's wrong, in a sentence or two. -->
+
+## Impact
+
+<!-- What it affects and how badly. -->
+
+## Evidence
+
+<!-- file:line, logs, or steps to reproduce. -->
+
+## Proposed fix
+
+<!-- Optional. -->
+
+## Acceptance criteria
+
+- [ ]

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,22 @@
+---
+name: Task / improvement
+about: A change, refactor, or improvement to make.
+title: ""
+labels: ""
+---
+
+## Summary
+
+<!-- What needs to happen, in a sentence or two. -->
+
+## Why
+
+<!-- The motivation, or the problem this addresses. -->
+
+## Proposed approach
+
+<!-- Optional. How you'd tackle it. Delete if not yet known. -->
+
+## Acceptance criteria
+
+- [ ]

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+<!-- Personal repo. This template exists to keep PR bodies consistent, not to invite contributions. Delete any section that does not apply. -->
+
+## What & why
+
+<!-- One or two sentences: what this changes and the motivation. -->
+
+## Changes
+
+-
+
+## Notes
+
+<!-- Risks, trade-offs, follow-ups, or anything worth knowing on review. -->
+
+## Verification
+
+<!-- How this was checked: CI, local build/eval (nix flake check, the VM boot test), or manual steps. -->
+
+Closes #

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # .dotfiles
 
+[![CI](https://github.com/QuinnHerden/.dotfiles/actions/workflows/ci.yml/badge.svg)](https://github.com/QuinnHerden/.dotfiles/actions/workflows/ci.yml) [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+
 Personal Nix dotfiles: home-manager, nix-darwin, and NixOS across my Mac, my NixOS workstations, and a Podman dev container, plus a Claude Code setup (custom agents, skills, and a knowledge base).
 
 > **This is my personal setup, not a template.** Hostnames, hosts, and secrets are mine, and the `knowledge/` submodule is private. Fork and adapt at your own pace; don't expect it to run clean on your machine. It is meant to be *read* for patterns, not cloned wholesale.
@@ -16,6 +18,27 @@ Personal Nix dotfiles: home-manager, nix-darwin, and NixOS across my Mac, my Nix
 | `files/scripts/` | Bootstrap (`.init`, `.switch`, `.update`) and the `dev` Podman wrapper. |
 | `container/` | The dev-container image (Containerfile and entrypoint). |
 | `.github/workflows/ci.yml` | CI: flake eval, lint, per-host builds, and a NixOS VM boot test. |
+
+```mermaid
+graph LR
+  flake["nix/flake.nix"]
+  flake --> darwin["darwinConfigurations"]
+  flake --> nixos["nixosConfigurations"]
+  flake --> home["homeConfigurations"]
+  darwin --> mac["mac-papi"]
+  nixos --> nbox["nix-box"]
+  nixos --> ndots["nix-dots"]
+  home --> dev["dev@dev-container"]
+  home --> kali["quinnherden@kali-bug"]
+  mods["nix/modules/{home,system,packages}"]
+  mac --> mods
+  nbox --> mods
+  ndots --> mods
+  dev --> mods
+  kali --> mods
+```
+
+The host matrix: each output kind maps to its host(s), and every host composes the shared `nix/modules` building blocks.
 
 ## Start here (reading, not installing)
 


### PR DESCRIPTION
The low-effort, high-signal subset of #144 (GitHub-native, no docs site / no build step).

- **README**: CI status badge + MIT license badge under the title; a compact Mermaid host-matrix diagram (flake to config kinds to hosts to shared modules), verified against `nix/flake.nix`.
- **`.github/PULL_REQUEST_TEMPLATE.md`**: What & why / Changes / Notes / Verification.
- **`.github/ISSUE_TEMPLATE/{task,bug}.md`**: match how issues actually get filed here (bug auto-labels `bug`).

These are for a consistent personal + Claude workflow, not a "please contribute" signal. The remaining #144 items (docs site, per-module READMEs, screenshots, CONTRIBUTING/CoC) stay deferred; templating/forkability is being elevated to its own issue.