### PR TITLE
README: correct host-matrix diagram (home-manager fan-out)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,25 +20,33 @@ Personal Nix dotfiles: home-manager, nix-darwin, and NixOS across my Mac, my Nix
 | `.github/workflows/ci.yml` | CI: flake eval, lint, per-host builds, and a NixOS VM boot test. |
 
 ```mermaid
-graph LR
+graph TD
+  hm["home-manager"]
   flake["nix/flake.nix"]
-  flake --> darwin["darwinConfigurations"]
-  flake --> nixos["nixosConfigurations"]
-  flake --> home["homeConfigurations"]
-  darwin --> mac["mac-papi"]
-  nixos --> nbox["nix-box"]
-  nixos --> ndots["nix-dots"]
-  home --> dev["dev@dev-container"]
-  home --> kali["quinnherden@kali-bug"]
-  mods["nix/modules/{home,system,packages}"]
-  mac --> mods
-  nbox --> mods
-  ndots --> mods
-  dev --> mods
-  kali --> mods
+
+  flake --> darwin["darwinConfigurations: mac-papi"]
+  flake --> nixos["nixosConfigurations: nix-box, nix-dots"]
+  flake --> home["homeConfigurations: dev@dev-container, quinnherden@kali-bug"]
+
+  hm -. "as a module" .-> darwin
+  hm -. "as a module" .-> nixos
+  hm -. "builds" .-> home
+
+  darwin --> sysd["modules/system: common + darwin"]
+  nixos --> sysn["modules/system: common + nixos"]
+  darwin --> mhi["modules/home/integrated"]
+  nixos --> mhi
+  home --> mhs["modules/home/standalone"]
+
+  mhi --> mhc["modules/home/content"]
+  mhs --> mhc
+  sysd --> pkg["modules/packages"]
+  sysn --> pkg
+  mhi --> pkg
+  mhs --> pkg
 ```
 
-The host matrix: each output kind maps to its host(s), and every host composes the shared `nix/modules` building blocks.
+The host matrix. Each flake output is a machine. home-manager is embedded as a module in the darwin and NixOS systems, and it builds the two standalone home configs. The darwin and NixOS hosts compose `modules/system` plus `modules/home/integrated`; the standalone home configs use only `modules/home/standalone`. Both home layers share `modules/home/content`, and the system and home package wrappers draw from `modules/packages`.
 
 ## Start here (reading, not installing)
 


### PR DESCRIPTION
Fixes two inaccuracies in the Mermaid diagram added in #147, verified against `nix/flake.nix`:

1. **Standalone home configs don't use `modules/system`.** `dev@dev-container` and `quinnherden@kali-bug` are home-manager-only (`modules/home/standalone`). The old diagram drew every host into `modules/{home,system,packages}`, which was wrong for those two.
2. **home-manager was invisible.** It's now shown embedded as a module in the darwin/NixOS systems and building the two standalone home configs.

The diagram now distinguishes the integrated path (darwin/NixOS: `modules/system` + `modules/home/integrated`) from the standalone path (`modules/home/standalone`), shows the shared `modules/home/content`, and that package wrappers draw from `modules/packages`.