### PR TITLE
Add multi-lens-review skill

### DIFF
--- a/files/home/.claude/skills/multi-lens-review/SKILL.md
+++ b/files/home/.claude/skills/multi-lens-review/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: multi-lens-review
+description: Run a rigorous multi-agent review of a substantial subject (a product, codebase, design, roadmap, plan, repo, or strategy) across several expert perspectives, then synthesize and adversarially stress-test the verdict. Use when the user wants a thorough assessment/audit/cohesion-or-quality review and a single-lens take would be too shallow ("assess X for cohesion", "review the roadmap", "is this design sound", "audit this across perspectives"). Spawns expert-lens subagents plus an adversarial critic, so it is multi-agent orchestration.
+---
+
+# Multi-lens review
+
+A managed multi-agent assessment. The pattern, in four phases:
+
+**Scout -> Assess (parallel expert lenses) -> Synthesize -> Adversarial critique.**
+
+- **Scout** maps the subject once into a shared base, so each lens does not re-read everything.
+- **Assess** runs several expert subagents in parallel, each judging one lens (one perspective) and returning a scored, evidence-grounded verdict.
+- **Synthesize** reconciles the lenses into one verdict, noting where they diverge.
+- **Critique** is an adversarial agent that tries to refute the synthesis and verifies the load-bearing claims. This is the quality lever: in practice it catches the synthesis overreaching or inheriting errors. Do not skip it.
+
+It is implemented as a workflow at `workflow.js` in this skill's directory, parameterized via `args`.
+
+## When to use
+
+- The subject is substantial and genuinely multi-faceted (it has a domain model AND a UX AND a strategy, etc.).
+- The user wants confidence, not a quick opinion: a cohesion read, a design review, a roadmap audit, a readiness or risk assessment.
+
+## When not to use
+
+- A narrow, single-perspective question (just answer it, or use one subagent).
+- A trivial subject. The orchestration is many agents and many tokens; reserve it for things that earn it.
+
+## How to run it
+
+1. **Scope it.** Settle four things (ask the user only if genuinely ambiguous):
+   - **subject**: what is being reviewed, in one phrase.
+   - **dimension**: what it is reviewed FOR (cohesion, quality, risk, readiness, soundness). Default: cohesion.
+   - **context**: the framing plus exactly where the source material is and how to read it (file paths, repos, `gh issue list ...` for an in-flight roadmap, which docs to read). The agents are only as good as this.
+   - **lenses**: 3-5 expert perspectives, each `{ key, agentType, focus }`. Pick `agentType`s for genuine perspective diversity from the domain (e.g. `data-engineer` for a data model, `system-architect` for structure, `ux-designer` for an interface, `business-mentor` for strategy/scope, `security-analyst` for trust surface, `process-analyst` for a workflow). Three identical lenses waste the run; diversity is the point.
+
+2. **Invoke the workflow** (this is the explicit opt-in for multi-agent orchestration, since a skill is calling it):
+
+   ```
+   Workflow({
+     scriptPath: "~/.claude/skills/multi-lens-review/workflow.js",
+     args: {
+       subject: "Motifs, a workflow + knowledge engine",
+       dimension: "cohesion",
+       context: "Code + docs at /home/dev/repos/motifs: read README, ROADMAP, docs/. Roadmap-in-flight: `gh issue list --repo SculptedSystems/motifs --state open`. Strategic frame: ...",
+       lenses: [
+         { key: "domain-data-model", agentType: "data-engineer", focus: "..." },
+         { key: "architecture-roadmap", agentType: "system-architect", focus: "..." },
+         { key: "ux-interaction", agentType: "ux-designer", focus: "..." },
+         { key: "product-strategy", agentType: "business-mentor", focus: "..." }
+       ]
+     }
+   })
+   ```
+
+   It runs in the background and returns `{ verdicts, synthesis, critique }`. The result can be large; extract the synthesis + critique + each lens score rather than reading the whole blob into context.
+
+3. **Relay AND weigh in.** Do not just paste the agents' output. Lead with the synthesized verdict (corrected by the critique), then add your own take, integrating context the agents did not have. The agents produce signal; you own the conclusion.
+
+## Notes
+
+- Pick lenses that can actually disagree; the value is in the spread, not in consensus.
+- The scout + the critic are what make this better than a flat fan-out: shared grounding in, adversarial check out.
+- Scale the lens count to the subject. Two for a small thing, five for a big one. More than five rarely adds signal.

--- a/files/home/.claude/skills/multi-lens-review/workflow.js
+++ b/files/home/.claude/skills/multi-lens-review/workflow.js
@@ -1,0 +1,79 @@
+export const meta = {
+  name: 'multi-lens-review',
+  description: 'Multi-agent review: a scout maps the subject, expert lenses assess in parallel, a synthesizer reconciles, an adversarial critic stress-tests the verdict',
+  phases: [
+    { title: 'Scout', detail: 'map the subject into a shared base' },
+    { title: 'Assess', detail: 'expert lenses assess in parallel' },
+    { title: 'Synthesize', detail: 'reconcile into one verdict' },
+    { title: 'Critique', detail: 'adversarial stress-test of the verdict' },
+  ],
+}
+
+// args (from the Workflow `args` input):
+//   subject   : string  - what is being reviewed
+//   dimension : string  - what it is reviewed FOR (cohesion | quality | risk | readiness | soundness). Default: cohesion
+//   context   : string  - the framing + where the source material is and how to read it (paths, repos, "run gh ...", docs to read)
+//   lenses    : [{ key, agentType, focus }] - the expert lenses. agentType is a subagent type (e.g. data-engineer, system-architect, ux-designer, business-mentor, security-analyst, process-analyst). 3-5 is the sweet spot. Pick for genuine perspective diversity.
+const a = args || {}
+const SUBJECT = a.subject || 'the subject under review'
+const DIMENSION = a.dimension || 'cohesion'
+const LENSES = (Array.isArray(a.lenses) && a.lenses.length) ? a.lenses : [
+  { key: 'architecture', agentType: 'system-architect', focus: 'Overall structure and whether the parts cohere into one whole.' },
+  { key: 'product-strategy', agentType: 'business-mentor', focus: 'Whether it is a coherent, well-scoped bet for its stage.' },
+]
+const CTX = `Assess ${SUBJECT} for ${DIMENSION}.\n\n${a.context || ''}`
+
+const SCOUT = { type:'object', additionalProperties:false, required:['overview','keyAspects','inFlightOrRoadmap','tensions','sources'], properties:{
+  overview:{type:'string'}, keyAspects:{type:'array',items:{type:'string'}}, inFlightOrRoadmap:{type:'string'},
+  tensions:{type:'array',items:{type:'string'}}, sources:{type:'array',items:{type:'string'}} } }
+const LENS = { type:'object', additionalProperties:false, required:['lens','score','strengths','issues','risks','recommendations'], properties:{
+  lens:{type:'string'}, score:{type:'number'}, strengths:{type:'array',items:{type:'string'}},
+  issues:{type:'array',items:{type:'object',additionalProperties:false,required:['issue','severity','why'],properties:{issue:{type:'string'},severity:{type:'string'},why:{type:'string'}}}},
+  risks:{type:'array',items:{type:'string'}}, recommendations:{type:'array',items:{type:'string'}} } }
+const SYNTH = { type:'object', additionalProperties:false, required:['overallScore','verdict','narrative','topIssues','recommendation'], properties:{
+  overallScore:{type:'number'}, verdict:{type:'string'}, narrative:{type:'string'}, topIssues:{type:'array',items:{type:'string'}}, recommendation:{type:'string'} } }
+const CRIT = { type:'object', additionalProperties:false, required:['overstated','strongestCounterCase','blindSpots','adjustedVerdict'], properties:{
+  overstated:{type:'boolean'}, strongestCounterCase:{type:'string'}, blindSpots:{type:'array',items:{type:'string'}}, adjustedVerdict:{type:'string'} } }
+
+phase('Scout')
+const scout = await agent(`${CTX}
+
+You are the SCOUT. Inspect the subject thoroughly (read the cited files/repos, fetch the cited state) and produce a shared map for the assessor agents: an overview, the key aspects/components, any in-flight state or roadmap, and the key tensions. Be concrete and cite sources. Downstream agents rely on this so they need not re-read everything.`,
+  { label:'scout', phase:'Scout', schema: SCOUT })
+const map = JSON.stringify(scout)
+
+phase('Assess')
+const verdicts = (await parallel(LENSES.map(l => () =>
+  agent(`${CTX}
+
+Shared scout map (JSON):
+${map}
+
+Your lens: ${l.key}. ${l.focus}
+
+Return a verdict from this lens: a 1-10 score (10 = excellent on this dimension), strengths, issues (each with severity high/medium/low and why), risks, and concrete recommendations. Ground every point in the actual evidence; read the source material yourself where the scout map is thin.`,
+    { label:`lens:${l.key}`, phase:'Assess', agentType:l.agentType, schema: LENS })
+))).filter(Boolean)
+
+phase('Synthesize')
+const synth = await agent(`${CTX}
+
+The expert lens verdicts (JSON):
+${JSON.stringify(verdicts)}
+
+Synthesize ONE assessment. Reconcile agreement and tension across lenses (note where lenses diverge and why). Give: overallScore (1-10), a one-line verdict, a narrative (the story: where it hangs together and where it does not), the topIssues that matter most across lenses, and a single clear recommendation.`,
+  { label:'synthesize', phase:'Synthesize', schema: SYNTH })
+
+phase('Critique')
+const crit = await agent(`${CTX}
+
+A synthesized assessment (JSON):
+${JSON.stringify(synth)}
+
+The underlying lens verdicts (JSON):
+${JSON.stringify(verdicts)}
+
+You are an adversarial critic. Try to REFUTE the synthesis. Is its verdict overstated or understated? What is the strongest counter-case? What did all the lenses miss (blind spots)? Verify the load-bearing claims against the source where you can. Give an adjustedVerdict if warranted. Default to skepticism.`,
+  { label:'critique', phase:'Critique', schema: CRIT })
+
+return { verdicts, synthesis: synth, critique: crit }


### PR DESCRIPTION
Saves the multi-agent review orchestration (scout -> parallel expert lenses -> synthesize -> adversarial critic) as a reusable skill, generalized from the Motifs cohesion assessment.

- `skills/multi-lens-review/workflow.js` - parameterized via `args` (subject, dimension, context, lenses).
- `skills/multi-lens-review/SKILL.md` - when to use, how to scope + invoke, and the relay-and-weigh-in step.

Files only; no flake/runtime impact. node --check passes.