### PR TITLE
Swap Terraform for OpenTofu

### DIFF
--- a/nix/modules/home/content/base.nix
+++ b/nix/modules/home/content/base.nix
@@ -126,8 +126,8 @@
       # ssh
       rmkh = "rm ~/.ssh/known_hosts";
 
-      # terraform
-      tf = "terraform";
+      # opentofu
+      tf = "tofu";
 
       # thefuck
       fuck = "f";

--- a/nix/modules/packages/infra.nix
+++ b/nix/modules/packages/infra.nix
@@ -6,7 +6,7 @@
       kubectx
       kubernetes-helm
       packer
-      terraform
+      opentofu
       tflint
     ];
 


### PR DESCRIPTION
Switch the IaC CLI from Terraform to OpenTofu.

## Why
- `pkgs.terraform` is **unfree** in nixpkgs since the BUSL relicense; `pkgs.opentofu` is MPL-2.0 and stays free.
- Drop-in for the Hetzner Cloud + Proxmox community-provider stack: same HCL, same state, same `init`/`plan`/`apply`.

## Changes
- `nix/modules/packages/infra.nix`: `terraform` -> `opentofu`
- `nix/modules/home/content/base.nix`: shell alias `tf = "terraform"` -> `tf = "tofu"`

`tflint` is retained (parses HCL directly, works with OpenTofu). `nixosConfigurations` evaluates clean.

## First-use notes (external, not addressed here)
- **Provider registry:** OpenTofu defaults to `registry.opentofu.org`. The Hetzner/Proxmox providers are mirrored there; verify on first `tofu init`, or pin explicit source addresses if needed.
- **State:** byte-compatible at the swap point, but `tofu apply` may rewrite state in a way that isn't cleanly reversible to Terraform. Back up state before the first apply.
- `.terraform.lock.hcl` will churn on first `tofu init -upgrade` (per-registry hashes). Expected.