### PR TITLE
Fix broken git credential helper when gh is absent

### DIFF
--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -56,8 +56,14 @@ if [ -d /home/dev/.dev-state ]; then
   ln -sfn /home/dev/.dev-state/config/gh "$HOME/.config/gh"
 fi
 
-# Fix git credential helper for container context
-git config --global credential.helper "!$(which gh) auth git-credential"
+# Fix git credential helper for container context. Resolve gh lazily at git
+# runtime (it is on PATH when git invokes the helper) and only set it if present,
+# so an absent gh does not leave a broken `!  auth git-credential` helper.
+if command -v gh >/dev/null 2>&1; then
+  git config --global credential.helper "!gh auth git-credential"
+else
+  git config --global --unset-all credential.helper 2>/dev/null || true
+fi
 
 # Install/repair Claude Code (runtime install — cached via npm prefix volume).
 # claude-code ships a JS stub plus a platform-native optional dependency that is


### PR DESCRIPTION
Closes #122.

## Problem
`container/entrypoint.sh` set the helper with `"!$(which gh) auth git-credential"`. When `gh` is not on PATH at entrypoint time, `$(which gh)` is empty and the helper becomes `!  auth git-credential` — git then tries to run `auth` as a command on every authenticated op and fails with a confusing error.

## Fix
- Guard on `gh` presence with `command -v gh`; only write the helper when it exists.
- Use the lazy `!gh auth git-credential` form (no embedded absolute path). `gh` resolves on PATH when git invokes the helper, which also avoids baking a stale Nix store path.
- `else` branch unsets any prior helper, so a re-run with `gh` absent can't leave a stale/broken one behind (the entrypoint runs on every container start). Closes the set-never-unset gap the review flagged.

## Acceptance criteria
- [x] Helper only written when `gh` is present.
- [x] Written helper is `!gh auth git-credential` (no absolute path).
- [x] A container without `gh` completes entrypoint with no broken helper (and clears any stale one).

No `nix/**` files touched, so build/VM-test jobs skip; lint (shellcheck) runs.