### PR TITLE
Reconverge flake.lock channel drift (nixpkgs/darwin/home-manager)

### DIFF
--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749744770,
-        "narHash": "sha256-MEM9XXHgBF/Cyv1RES1t6gqAX7/tvayBC1r/KPyK1ls=",
+        "lastModified": 1769584835,
+        "narHash": "sha256-I21RElVDKF8YhA24LMDzXqb4AmkreYfcIYo7SGU9Jek=",
         "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "536f951efb1ccda9b968e3c9dee39fbeb6d3fdeb",
+        "rev": "d6c2f8abfb695d5eae734386257da7fb0ffa8fca",
         "type": "github"
       },
       "original": {
@@ -44,11 +44,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1778507602,
-        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
+        "lastModified": 1781733627,
+        "narHash": "sha256-U3yTuGBnmXvXoQI3qkpfEDsn9RovQPAjN7ndRco+3u0=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
+        "rev": "3bbec39bc90eadfa031e6f3b77272f3f60803e39",
         "type": "github"
       },
       "original": {
@@ -85,11 +85,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755776884,
-        "narHash": "sha256-CPM7zm6csUx7vSfKvzMDIjepEJv1u/usmaT7zydzbuI=",
+        "lastModified": 1763992789,
+        "narHash": "sha256-WHkdBlw6oyxXIra/vQPYLtqY+3G8dUVZM8bEXk0t8x4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4fb695d10890e9fc6a19deadf85ff79ffb78da86",
+        "rev": "44831a7eaba4360fb81f2acc5ea6de5fde90aaa3",
         "type": "github"
       },
       "original": {
@@ -101,11 +101,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1781607440,
-        "narHash": "sha256-rxO+uc/KFbSJp+pgyXRuAX6QlG9hJdnt0BXpEQRXY+U=",
+        "lastModified": 1770073757,
+        "narHash": "sha256-Vy+G+F+3E/Tl+GMNgiHl9Pah2DgShmIUBJXmbiQPHbI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
+        "rev": "47472570b1e607482890801aeaf29bfb749884f6",
         "type": "github"
       },
       "original": {

--- a/nix/modules/system/darwin/packages/commsPackages.nix
+++ b/nix/modules/system/darwin/packages/commsPackages.nix
@@ -16,9 +16,7 @@ in
   config = lib.mkIf config.commsPackages.enable {
     environment.systemPackages = pkg.common pkgs;
     homebrew = {
-      brews = pkg.darwin.brews;
-      casks = pkg.darwin.casks;
-      masApps = pkg.darwin.masApps;
+      inherit (pkg.darwin) brews casks masApps;
     };
   };
 

--- a/nix/modules/system/darwin/packages/devPackages.nix
+++ b/nix/modules/system/darwin/packages/devPackages.nix
@@ -16,9 +16,7 @@ in
   config = lib.mkIf config.devPackages.enable {
     environment.systemPackages = pkg.common pkgs;
     homebrew = {
-      brews = pkg.darwin.brews;
-      casks = pkg.darwin.casks;
-      masApps = pkg.darwin.masApps;
+      inherit (pkg.darwin) brews casks masApps;
     };
   };
 

--- a/nix/modules/system/darwin/packages/experimentalPackages.nix
+++ b/nix/modules/system/darwin/packages/experimentalPackages.nix
@@ -16,9 +16,7 @@ in
   config = lib.mkIf config.experimentalPackages.enable {
     environment.systemPackages = pkg.common pkgs;
     homebrew = {
-      brews = pkg.darwin.brews;
-      casks = pkg.darwin.casks;
-      masApps = pkg.darwin.masApps;
+      inherit (pkg.darwin) brews casks masApps;
     };
   };
 

--- a/nix/modules/system/darwin/packages/extraPackages.nix
+++ b/nix/modules/system/darwin/packages/extraPackages.nix
@@ -16,9 +16,7 @@ in
   config = lib.mkIf config.extraPackages.enable {
     environment.systemPackages = pkg.common pkgs;
     homebrew = {
-      brews = pkg.darwin.brews;
-      casks = pkg.darwin.casks;
-      masApps = pkg.darwin.masApps;
+      inherit (pkg.darwin) brews casks masApps;
     };
   };
 

--- a/nix/modules/system/darwin/packages/infraPackages.nix
+++ b/nix/modules/system/darwin/packages/infraPackages.nix
@@ -16,9 +16,7 @@ in
   config = lib.mkIf config.infraPackages.enable {
     environment.systemPackages = pkg.common pkgs;
     homebrew = {
-      brews = pkg.darwin.brews;
-      casks = pkg.darwin.casks;
-      masApps = pkg.darwin.masApps;
+      inherit (pkg.darwin) brews casks masApps;
     };
   };
 

--- a/nix/modules/system/darwin/packages/opsPackages.nix
+++ b/nix/modules/system/darwin/packages/opsPackages.nix
@@ -16,9 +16,7 @@ in
   config = lib.mkIf config.opsPackages.enable {
     environment.systemPackages = pkg.common pkgs;
     homebrew = {
-      brews = pkg.darwin.brews;
-      casks = pkg.darwin.casks;
-      masApps = pkg.darwin.masApps;
+      inherit (pkg.darwin) brews casks masApps;
     };
   };
 

--- a/nix/modules/system/darwin/packages/secPackages.nix
+++ b/nix/modules/system/darwin/packages/secPackages.nix
@@ -16,9 +16,7 @@ in
   config = lib.mkIf config.secPackages.enable {
     environment.systemPackages = pkg.common pkgs;
     homebrew = {
-      brews = pkg.darwin.brews;
-      casks = pkg.darwin.casks;
-      masApps = pkg.darwin.masApps;
+      inherit (pkg.darwin) brews casks masApps;
     };
   };
 


### PR DESCRIPTION
Closes #124.

## Change
`nix flake update` to bring the three inputs into one 25.05 window:

| input | before | after |
|---|---|---|
| nix-darwin | 2025-06-12 | 2026-01-28 |
| home-manager | 2025-08-21 | 2025-11-24 |
| nixpkgs (`nixos-25.05`) | 2026-01-02 | unchanged (already tip) |

Spread tightened from ~7 months to ~2. (`git-hooks` also bumped; it intentionally pins its own nixpkgs for hook tools and does not follow ours.)

## Verification
- nixpkgs root node still tracks `nixos-25.05`.
- All five configs evaluate locally: `nix-box`, `nix-dots`, `mac-papi`, and both home configs (`dev@dev-container`, `quinnherden@kali-bug`).
- CI runs the authoritative gate: `nix flake check` + all host builds + the NixOS VM boot test.

## Acceptance criteria
- [x] Inputs' `lastModified` fall within a tight window (~2 months vs ~7).
- [x] nixpkgs still tracks `nixos-25.05`.
- [ ] `nix flake check` passes (CI).
- [ ] All hosts + container config build (CI).