### PR TITLE
Harden SSH and add a firewall on NixOS hosts

### DIFF
--- a/nix/hosts/nix-box/default.nix
+++ b/nix/hosts/nix-box/default.nix
@@ -29,6 +29,7 @@
 
   wifi.enable = true;
   openssh.enable = true;
+  firewall.enable = true;
   services.tailscale.enable = true;
 
   bluetooth.enable = true;

--- a/nix/hosts/nix-dots/default.nix
+++ b/nix/hosts/nix-dots/default.nix
@@ -29,6 +29,7 @@
 
   wifi.enable = true;
   openssh.enable = true;
+  firewall.enable = true;
   services.tailscale.enable = true;
 
   bluetooth.enable = true;

--- a/nix/modules/system/nixos/networking/default.nix
+++ b/nix/modules/system/nixos/networking/default.nix
@@ -5,6 +5,7 @@
 {
 
   imports = [
+    ./firewall.nix
     ./hostname.nix
     ./openssh.nix
     ./wifi.nix

--- a/nix/modules/system/nixos/networking/firewall.nix
+++ b/nix/modules/system/nixos/networking/firewall.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  config,
+  ...
+}:
+
+{
+
+  options = {
+    firewall = {
+      enable = lib.mkEnableOption "enables the firewall";
+    };
+  };
+
+  config = lib.mkIf config.firewall.enable {
+    networking.firewall = {
+      enable = true;
+
+      # Trust the Tailscale interface so services (SSH included) are reachable
+      # over the tailnet but not the public interface. Only meaningful when
+      # tailscale is enabled, so gate it on that.
+      trustedInterfaces = lib.mkIf config.services.tailscale.enable [ "tailscale0" ];
+    };
+  };
+
+}

--- a/nix/modules/system/nixos/networking/openssh.nix
+++ b/nix/modules/system/nixos/networking/openssh.nix
@@ -16,11 +16,18 @@
     services.openssh = {
       enable = true;
 
+      # Do not open port 22 on the public interface. SSH is reached over the
+      # Tailscale interface only (the firewall module trusts tailscale0).
+      openFirewall = false;
+
       settings = {
-        PermitRootLogin = "yes";
-        PasswordAuthentication = true;
+        # Key-only, no root: brute-force over the public net has no surface, and
+        # these are physical workstations with console recovery if keys break.
+        PermitRootLogin = "no";
+        PasswordAuthentication = false;
       };
     };
+
   };
 
 }


### PR DESCRIPTION
Closes #118.

## Changes
- **`openssh.nix`**: `PermitRootLogin = "no"`, `PasswordAuthentication = false`, and `openFirewall = false` so port 22 is never opened on the public interface.
- **New `networking/firewall.nix`** module (`firewall.enable`): enables the firewall and trusts `tailscale0`, gated on `services.tailscale.enable`. Kept as its own concern (not inside `openssh.nix`) so disabling SSH can't silently drop the host firewall, and the tailnet trust depends on tailscale actually being on. This was the review's main structural finding.
- Both `nix-box` and `nix-dots` set `firewall.enable = true`.

Net posture: SSH reachable only over the tailnet, key-only, no root, no password auth.

## Verification (eval)
Both hosts: `PermitRootLogin=no`, `PasswordAuthentication=false`, `firewall.enable=true`, `trustedInterfaces=["tailscale0" "lo"]`, `allowedTCPPorts=[]`. Derivations are byte-identical to the inline version, confirming the module split is behavior-preserving.

## Root-login posture
`"no"` (strictest) per maintainer decision: these are physical workstations with console recovery and a sudo user, so key-only + no-root has no true lockout path.

## Acceptance criteria
- [x] `PasswordAuthentication = false` on all NixOS hosts.
- [x] `PermitRootLogin = "no"`.
- [x] `networking.firewall.enable = true`.
- [x] Port 22 reachable only over Tailscale, not the public interface (`openFirewall=false` + `trustedInterfaces=["tailscale0"]`, `allowedTCPPorts=[]`).
- [ ] Both hosts rebuild cleanly (CI).

## Note for deploy
First `nixos-rebuild switch` on each host: make sure your tailnet is up and your key works before relying on it remotely. Lost-key/tailscale-down recovery is via physical console.