### PR TITLE
Document the socket confinement-bypass blast radius in dev

### DIFF
--- a/files/scripts/dev
+++ b/files/scripts/dev
@@ -81,6 +81,12 @@ if [ -z "${DEV_DOCKER_SOCK:-}" ] && [ -f "$SOCK_PREF_FILE" ]; then
 fi
 socket_mount=()
 if [ "${DEV_DOCKER_SOCK:-}" = "1" ] && [ -n "$PODMAN_SOCKET" ]; then
+  # `label=disable` turns off SELinux confinement for this container so it can
+  # write the bind-mounted socket. Combined with the host-root-equivalent socket,
+  # this gives the container full control of the host runtime: treat any code run
+  # inside it (including Claude in dangerous mode) as running on the host. To
+  # narrow this, front the socket with a docker-socket-proxy that exposes only
+  # the needed API surface and point DOCKER_HOST at the proxy instead.
   socket_mount=(-v "$PODMAN_SOCKET:/var/run/docker.sock" --security-opt label=disable)
 fi
 


### PR DESCRIPTION
Closes #119.

Most of this issue was already addressed by prior work; this PR closes the last criterion.

## Status of the criteria
- [x] **`skipDangerousModePermissionPrompt` no longer hardcoded `true`.** It is gone from `files/home/.claude/settings.json` entirely. Dangerous mode is now an explicit, opt-in alias (`dangerclaude = "claude --dangerously-skip-permissions"` in `base.nix`) the user types deliberately, rather than a silent committed default. This is the "gate it per session, don't bake it in" the issue asked for.
- [x] **Socket access stays opt-in.** Mounted only via `dev --sock on` (a marker file intentionally not synced across machines) or `DEV_DOCKER_SOCK=1` per launch.
- [x] **A note documents how to reduce the socket's confinement bypass.** This PR adds a comment at the socket-mount site explaining that `--security-opt label=disable` drops SELinux confinement, that the container then has host-runtime control (so anything inside it, including Claude in dangerous mode, is effectively host-level), and how to narrow it with a `docker-socket-proxy` + `DOCKER_HOST`.

## Not done (deliberately out of scope)
Implementing the `docker-socket-proxy` itself is a larger, optional change the issue marked "Consider." Documented as the mitigation path; happy to open a separate issue if we want to build it.

Comment-only change to `files/scripts/dev`; no `nix/**` touched, so builds skip and lint (shellcheck) runs.