### PR TITLE
Add spacectl (Spacelift CLI) to infra packages

### DIFF
--- a/nix/modules/packages/infra.nix
+++ b/nix/modules/packages/infra.nix
@@ -7,6 +7,7 @@
       kubernetes-helm
       packer
       opentofu
+      spacectl
       tflint
     ];
 


### PR DESCRIPTION
Adds `spacectl`, the Spacelift client/CLI, to the common infra package set (`nix/modules/packages/infra.nix`).

("spaceliftctl" isn't a nixpkgs attr; the Spacelift CLI is `spacectl`, v1.22.0.)

`nix-dots` evaluates clean with it included. CI builds verify the rest.