### PR TITLE
Extract shared NixOS workstation base for nix-box and nix-dots

### DIFF
--- a/nix/hosts/_shared/nixos-workstation.nix
+++ b/nix/hosts/_shared/nixos-workstation.nix
@@ -1,0 +1,39 @@
+# Shared base for the NixOS workstations (nix-box, nix-dots). Holds the common
+# system, home, user, and service toggles. Each host imports this and sets only
+# its hostname, its hardware config, and its package-category overrides.
+_:
+
+{
+  system.stateVersion = "24.11";
+  x86_64-linuxSystem.enable = true;
+
+  hostname.enable = true;
+
+  commonBaseHome = {
+    enable = true;
+    name = "quinnherden";
+  };
+  linuxBaseHome = {
+    enable = true;
+    name = "quinnherden";
+  };
+
+  quinnherdenUser.enable = true;
+
+  pam.enable = true;
+
+  wifi.enable = true;
+  openssh.enable = true;
+  firewall.enable = true;
+  services.tailscale.enable = true;
+
+  bluetooth.enable = true;
+
+  keyd.enable = true;
+  libinput.enable = true;
+
+  i3.enable = true;
+  redshift.enable = true;
+
+  docker.enable = true;
+}

--- a/nix/hosts/nix-box/default.nix
+++ b/nix/hosts/nix-box/default.nix
@@ -5,51 +5,13 @@
 {
   imports = [
     ./hardware-configuration.nix
+    ../_shared/nixos-workstation.nix
   ];
-  system.stateVersion = "24.11";
-  x86_64-linuxSystem.enable = true;
 
-  hostname = {
-    enable = true;
-    name = "nix-box";
-  };
-
-  commonBaseHome = {
-    enable = true;
-    name = "quinnherden";
-  };
-  linuxBaseHome = {
-    enable = true;
-    name = "quinnherden";
-  };
-
-  quinnherdenUser.enable = true;
-
-  pam.enable = true;
-
-  wifi.enable = true;
-  openssh.enable = true;
-  firewall.enable = true;
-  services.tailscale.enable = true;
-
-  bluetooth.enable = true;
-
-  keyd.enable = true;
-  libinput.enable = true;
-
-  i3.enable = true;
-  redshift.enable = true;
-
-  docker.enable = true;
+  hostname.name = "nix-box";
 
   ############
   # packages #
   ############
   opsPackages.enable = true;
-  devPackages.enable = false;
-  infraPackages.enable = false;
-  secPackages.enable = false;
-  commsPackages.enable = false;
-  extraPackages.enable = false;
-
 }

--- a/nix/hosts/nix-dots/default.nix
+++ b/nix/hosts/nix-dots/default.nix
@@ -5,42 +5,10 @@
 {
   imports = [
     ./hardware-configuration.nix
+    ../_shared/nixos-workstation.nix
   ];
-  system.stateVersion = "24.11";
-  x86_64-linuxSystem.enable = true;
 
-  hostname = {
-    enable = true;
-    name = "nix-dots";
-  };
-
-  commonBaseHome = {
-    enable = true;
-    name = "quinnherden";
-  };
-  linuxBaseHome = {
-    enable = true;
-    name = "quinnherden";
-  };
-
-  quinnherdenUser.enable = true;
-
-  pam.enable = true;
-
-  wifi.enable = true;
-  openssh.enable = true;
-  firewall.enable = true;
-  services.tailscale.enable = true;
-
-  bluetooth.enable = true;
-
-  keyd.enable = true;
-  libinput.enable = true;
-
-  i3.enable = true;
-  redshift.enable = true;
-
-  docker.enable = true;
+  hostname.name = "nix-dots";
 
   ############
   # packages #
@@ -51,5 +19,4 @@
   secPackages.enable = true;
   commsPackages.enable = true;
   extraPackages.enable = true;
-
 }


### PR DESCRIPTION
Closes #127.

## Problem
`nix-box` and `nix-dots` duplicated the same system/home/user/service block, differing only in hostname and which package categories are enabled. Duplication drifts silently.

## Change
- New `nix/hosts/_shared/nixos-workstation.nix` holds the common block: `stateVersion`, `x86_64-linuxSystem`, `hostname.enable`, `commonBaseHome`/`linuxBaseHome`, `quinnherdenUser`, and the service toggles (pam, wifi, openssh, firewall, tailscale, bluetooth, keyd, libinput, i3, redshift, docker).
- Each host now sets only its `hostname.name`, its `hardware-configuration.nix`, and its package-category overrides. `nix-box` drops from ~50 lines to ~16.

## Verification
Both hosts evaluate to **byte-identical derivations** vs main (`nix-box` `h74axrd9…`, `nix-dots` `ijw2qb3s…`), confirming the extraction is purely behavior-preserving.

## Note
The shared module uses `_:` rather than the usual `{ ... }:` header: it takes no module args, and the bumped statix flags an empty `{ ... }:` pattern on a module that has no `imports`. The host files keep `{ ... }:` since they have imports.

## Acceptance criteria
- [x] Common service toggles live in one shared module.
- [x] Each host file sets only hostname + package overrides + hardware config.
- [x] Both hosts evaluate to the same effective config as before (identical drvPath).