### PR TITLE
Make hosts data via an mkHost builder (#148, part 1)

### DIFF
--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -51,14 +51,81 @@
             shellcheck.enable = true;
           };
         };
-      # Shared so the VM boot test and the real config cannot drift.
-      nixDotsModules = [
+      # Module list for a NixOS host. Shared by mkHost and the VM boot test so
+      # the test and the real config cannot drift.
+      nixosSystemModules = hostPath: [
         home-manager.nixosModules.default
-        ./hosts/nix-dots
+        hostPath
         ./modules/home/integrated
         ./modules/system/common
         ./modules/system/nixos
       ];
+
+      nixDotsModules = nixosSystemModules ./hosts/nix-dots;
+
+      # Build a host config from its spec. Each builder type folds in its
+      # standard module list, so a host is data (an entry in `hosts` below),
+      # not a copy-pasted builder block.
+      mkHost =
+        spec:
+        if spec.builder == "nixos" then
+          nixpkgs.lib.nixosSystem {
+            specialArgs = { inherit inputs; };
+            modules = nixosSystemModules spec.hostPath;
+          }
+        else if spec.builder == "darwin" then
+          darwin.lib.darwinSystem {
+            specialArgs = { inherit inputs; };
+            modules = [
+              home-manager.darwinModules.default
+              spec.hostPath
+              ./modules/home/integrated
+              ./modules/system/common
+              ./modules/system/darwin
+            ];
+          }
+        else
+          home-manager.lib.homeManagerConfiguration {
+            pkgs = nixpkgs.legacyPackages.${spec.system};
+            extraSpecialArgs = { inherit inputs; };
+            modules = [
+              spec.hostPath
+              ./modules/home/standalone
+            ];
+          };
+
+      # The host matrix. Adding a machine is an entry here plus its host dir.
+      hosts = {
+        nixos = {
+          nix-box = {
+            builder = "nixos";
+            hostPath = ./hosts/nix-box;
+          };
+          nix-dots = {
+            builder = "nixos";
+            hostPath = ./hosts/nix-dots;
+          };
+        };
+        # Docs: https://daiderd.com/nix-darwin/manual/index.html
+        darwin = {
+          mac-papi = {
+            builder = "darwin";
+            hostPath = ./hosts/mac-papi;
+          };
+        };
+        home = {
+          "quinnherden@kali-bug" = {
+            builder = "home";
+            system = "aarch64-linux";
+            hostPath = ./hosts/kali-bug;
+          };
+          "dev@dev-container" = {
+            builder = "home";
+            system = "aarch64-linux";
+            hostPath = ./hosts/dev-container;
+          };
+        };
+      };
     in
     {
 
@@ -76,63 +143,11 @@
         }
       );
 
-      darwinConfigurations = {
-        # Docs: https://daiderd.com/nix-darwin/manual/index.html
+      darwinConfigurations = nixpkgs.lib.mapAttrs (_: mkHost) hosts.darwin;
 
-        "mac-papi" = darwin.lib.darwinSystem {
-          specialArgs = { inherit inputs; };
-          modules = [
-            home-manager.darwinModules.default
-            ./hosts/mac-papi
-            ./modules/home/integrated
-            ./modules/system/common
-            ./modules/system/darwin
-          ];
-        };
+      homeConfigurations = nixpkgs.lib.mapAttrs (_: mkHost) hosts.home;
 
-      };
-
-      homeConfigurations = {
-
-        "quinnherden@kali-bug" = home-manager.lib.homeManagerConfiguration {
-          pkgs = nixpkgs.legacyPackages.aarch64-linux;
-          extraSpecialArgs = { inherit inputs; };
-          modules = [
-            ./hosts/kali-bug
-            ./modules/home/standalone
-          ];
-        };
-
-        "dev@dev-container" = home-manager.lib.homeManagerConfiguration {
-          pkgs = nixpkgs.legacyPackages.aarch64-linux;
-          extraSpecialArgs = { inherit inputs; };
-          modules = [
-            ./hosts/dev-container
-            ./modules/home/standalone
-          ];
-        };
-
-      };
-
-      nixosConfigurations = {
-
-        "nix-box" = nixpkgs.lib.nixosSystem {
-          specialArgs = { inherit inputs; };
-          modules = [
-            home-manager.nixosModules.default
-            ./hosts/nix-box
-            ./modules/home/integrated
-            ./modules/system/common
-            ./modules/system/nixos
-          ];
-        };
-
-        "nix-dots" = nixpkgs.lib.nixosSystem {
-          specialArgs = { inherit inputs; };
-          modules = nixDotsModules;
-        };
-
-      };
+      nixosConfigurations = nixpkgs.lib.mapAttrs (_: mkHost) hosts.nixos;
 
       # Boot nix-dots in a QEMU VM and assert it actually comes up (building the
       # toplevel only proves it compiles). Run by the nixos-vm-test CI job on a


### PR DESCRIPTION
Part of #148 (forkable flake). First of several staged PRs.

## Change
Collapse the five hand-listed builder blocks in `flake.nix` into one `mkHost` function driven by a `hosts` spec matrix:

```nix
nixosConfigurations  = mapAttrs (_: mkHost) hosts.nixos;
darwinConfigurations = mapAttrs (_: mkHost) hosts.darwin;
homeConfigurations   = mapAttrs (_: mkHost) hosts.home;
```

`mkHost` switches on `spec.builder` (`nixos`/`darwin`/`home`) and folds in that type's standard module list. Adding a machine is now a `hosts` entry plus its host dir, not a copy-pasted builder block. The nixos module list is factored into `nixosSystemModules`, shared by `mkHost` and the VM boot test so they still cannot drift.

## Behavior-preserving (verified)
All six derivations evaluate **byte-identical** to main:

| config | result |
|---|---|
| nixos `nix-box` | identical drvPath |
| nixos `nix-dots` | identical drvPath |
| darwin `mac-papi` | identical drvPath |
| home `quinnherden@kali-bug` | identical drvPath |
| home `dev@dev-container` | identical drvPath |
| check `nix-dots-boot` | identical drvPath |

## Still to come (later PRs, per the architect/security review on #148)
- Public/private seam: `inputs.private` defaulting to an in-repo stub, backed by a private submodule (the `knowledge/` pattern). No sops-nix/agenix needed — security review found no true secrets in the tree (the WireGuard private key is already out-of-band).
- Relocate identifiers (SSH pubkey, username, hostnames) to the private layer; delete the dead `vpn-us-ga-285` module.
- A `hosts/_template` example + "add a machine" / "fork this" docs.

Decisions still open for those PRs: private-layer mechanism (hybrid submodule vs pure flake input), how far to genericize `username` (11 files), and whether CI builds the private configs or only the public template.