### PR TITLE
Point knowledge submodule at renamed dotfiles-knowledge repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "files/home/.claude/knowledge"]
 	path = files/home/.claude/knowledge
-	url = https://github.com/QuinnHerden/claude-knowledge.git
+	url = https://github.com/QuinnHerden/dotfiles-knowledge.git


### PR DESCRIPTION
Renamed the private knowledge repo `claude-knowledge` -> `dotfiles-knowledge` for a consistent `dotfiles-*` naming convention (alongside the new `dotfiles-private` for #148).

Updates the submodule URL in `.gitmodules` to the new name. GitHub redirects the old URL, so this is hygiene, not a fix. Submodule fetch verified against the new URL.

No `nix/**` touched; lint only.