### PR TITLE
Add public/private seam: overridable private overlay (#148, part 2)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "files/home/.claude/knowledge"]
 	path = files/home/.claude/knowledge
 	url = https://github.com/QuinnHerden/dotfiles-knowledge.git
+[submodule "nix/private"]
+	path = nix/private
+	url = https://github.com/QuinnHerden/dotfiles-private.git

--- a/files/scripts/.switch
+++ b/files/scripts/.switch
@@ -10,7 +10,16 @@ fi
 
 if [ "$system_type" = "Linux" ]; then
   if command -v nixos-rebuild >/dev/null 2>&1; then
-    sudo nixos-rebuild switch --flake "$HOME/.dotfiles/nix"
+    # Pull real identifiers from the private overlay (nix/private submodule);
+    # the public flake defaults to the generic stub when this is omitted.
+    priv="$HOME/.dotfiles/nix/private"
+    if [ -e "$priv/default.nix" ]; then
+      sudo nixos-rebuild switch --flake "$HOME/.dotfiles/nix" \
+        --override-input private "path:$priv"
+    else
+      echo "warning: private overlay missing at $priv (run: git submodule update --init); using public stub" >&2
+      sudo nixos-rebuild switch --flake "$HOME/.dotfiles/nix"
+    fi
   else
     echo "Using host: $(whoami)@$(hostname)"
     if command -v home-manager >/dev/null 2>&1; then

--- a/files/scripts/.test
+++ b/files/scripts/.test
@@ -11,5 +11,14 @@ if [ "$system_type" = "Darwin" ]; then
 fi
 
 if [ "$system_type" = "Linux" ]; then
-  sudo nixos-rebuild test --flake "$HOME/.dotfiles/nix"
+  # Pull real identifiers from the private overlay (nix/private submodule);
+  # the public flake defaults to the generic stub when this is omitted.
+  priv="$HOME/.dotfiles/nix/private"
+  if [ -e "$priv/default.nix" ]; then
+    sudo nixos-rebuild test --flake "$HOME/.dotfiles/nix" \
+      --override-input private "path:$priv"
+  else
+    echo "warning: private overlay missing at $priv (run: git submodule update --init); using public stub" >&2
+    sudo nixos-rebuild test --flake "$HOME/.dotfiles/nix"
+  fi
 fi

--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -131,12 +131,25 @@
         "type": "github"
       }
     },
+    "private": {
+      "flake": false,
+      "locked": {
+        "path": "./private-stub",
+        "type": "path"
+      },
+      "original": {
+        "path": "./private-stub",
+        "type": "path"
+      },
+      "parent": []
+    },
     "root": {
       "inputs": {
         "darwin": "darwin",
         "git-hooks": "git-hooks",
         "home-manager": "home-manager",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs_2",
+        "private": "private"
       }
     }
   },

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -6,6 +6,14 @@
       url = "github:NixOS/nixpkgs/nixos-25.05";
     };
 
+    # Private "last-mile" layer (real identifiers). Defaults to an in-repo
+    # public stub so the public flake evaluates standalone (CI + forks). The
+    # owner's rebuild scripts override this to the nix/private submodule.
+    private = {
+      url = "path:./private-stub";
+      flake = false;
+    };
+
     darwin = {
       url = "github:nix-darwin/nix-darwin/nix-darwin-25.05";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -52,13 +60,16 @@
           };
         };
       # Module list for a NixOS host. Shared by mkHost and the VM boot test so
-      # the test and the real config cannot drift.
+      # the test and the real config cannot drift. Includes the private overlay
+      # (inputs.private), which defaults to the public stub and is overridden by
+      # the rebuild scripts; the VM test thus exercises the seam against the stub.
       nixosSystemModules = hostPath: [
         home-manager.nixosModules.default
         hostPath
         ./modules/home/integrated
         ./modules/system/common
         ./modules/system/nixos
+        (import inputs.private)
       ];
 
       nixDotsModules = nixosSystemModules ./hosts/nix-dots;

--- a/nix/modules/system/nixos/users/quinnherdenUser.nix
+++ b/nix/modules/system/nixos/users/quinnherdenUser.nix
@@ -26,9 +26,8 @@
 
       shell = pkgs.zsh;
 
-      openssh.authorizedKeys.keys = [
-        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDdFfEjaPcB7Pk1s6gR1mIOVqAgeZ3P1KUIJR4698mdQ"
-      ];
+      # Authorized SSH keys come from the private overlay (inputs.private), not
+      # the public tree. See nix/private-stub for the generic fallback.
     };
   };
 

--- a/nix/private-stub/default.nix
+++ b/nix/private-stub/default.nix
@@ -1,0 +1,7 @@
+# Public stub for the private "last-mile" layer (issue #148). A fork (and CI)
+# evaluates against this; the owner overrides inputs.private to a private repo.
+_: {
+  # No real authorized keys in the public tree. The owner's overlay supplies
+  # the real key; this placeholder keeps the public flake evaluatable.
+  users.users.quinnherden.openssh.authorizedKeys.keys = [ ];
+}


### PR DESCRIPTION
Part of #148 (forkable flake). Part 2 of 3. Implements **Option B** (private layer as an overridable flake input defaulting to a public stub).

## What
- **`inputs.private`** (`flake = false`) defaults to an in-repo public stub `nix/private-stub/`. It's folded into the shared `nixosSystemModules` list, so both `mkHost` and the VM boot test consume the same seam.
- **Relocated the real authorized SSH key** out of public `quinnherdenUser.nix` into a private submodule `nix/private` (repo `dotfiles-private`, private). The stub provides empty `authorizedKeys.keys` — **fails closed**, so no fork/CI build can inherit the owner's key.
- **Rebuild scripts** (`.switch`/`.test`) override the input to the private overlay when present, with a stub fallback + warning if the submodule isn't initialized.

## How it satisfies the constraints
- **Public flake evaluates standalone** (no private access): CI and forkers build against the stub. Verified `nix flake check` + builds pass with `nix/private` absent.
- **Owner gets the real config**: `--override-input private path:$HOME/.dotfiles/nix/private` restores the **byte-identical baseline derivation** (verified: `nix-box` drvPath matches `main`).
- **Committed + versioned** private layer via the submodule (your `knowledge/` pattern).

## Verification
| scenario | result |
|---|---|
| default (stub), `nix/private` absent | evaluates; `authorizedKeys = [ ]` |
| `flake check` without submodule | passes |
| owner override → real overlay | `nix-box` drvPath identical to `main` |
| darwin `mac-papi`, home `dev@dev-container` | unchanged (only nixos consumes `private`) |

## Review fixes applied
- **[High]** the VM boot test no longer drifts: `inputs.private` is in the shared module list, so the test exercises the seam against the stub.
- **[Low]** added a not-initialized guard + warning in the rebuild scripts.
- Kept `nix/private` as a submodule (your hybrid-submodule decision) rather than an out-of-tree clone.

## Intended changes vs main
Default `nix-box`/`nix-dots` builds no longer embed the SSH key (it moved to the private overlay); the boot-test derivation changes accordingly. These are the point of the PR, not regressions — the owner's real builds are byte-identical via the override.

## Still to come (part 3)
Per-platform public template hosts (`hosts/_template/*`) that CI builds, plus README "add a machine" / "fork this" docs (via technical-writer). Security review: the SSH key is a public key already in public history; no rotation needed (the private key was always out-of-band).