### PR TITLE
Add forkable per-platform template hosts + docs (#148, part 3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,9 @@ jobs:
       # Evaluates every output for every system without building (--no-build),
       # so one x86_64 runner catches broken modules and option mistakes across
       # all hosts (incl. aarch64 and darwin) without cross-compiling. The
-      # private knowledge/ submodule is intentionally not checked out: the flake
-      # uses mkOutOfStoreSymlink, so eval and build never read those files.
+      # private submodules are intentionally not checked out: knowledge/ is read
+      # via mkOutOfStoreSymlink, and nix/private defaults to the public stub
+      # (inputs.private), so eval and build never need the private repos.
       - name: nix flake check (all systems, eval only)
         run: nix flake check --no-build --all-systems ./nix
 
@@ -104,6 +105,16 @@ jobs:
           - name: mac-papi (aarch64-darwin)
             os: macos-latest
             attr: darwinConfigurations.mac-papi.system
+          # Generic forkable templates (hosts/_template). Built so the public
+          # layer is provably buildable without the private overlay. The darwin
+          # template is eval-only (flake check --all-systems) since its build
+          # path is already covered by mac-papi on the costly macOS runner.
+          - name: template nixos (x86_64-linux)
+            os: ubuntu-latest
+            attr: nixosConfigurations.template.config.system.build.toplevel
+          - name: template home (aarch64-linux)
+            os: ubuntu-24.04-arm
+            attr: homeConfigurations.template.activationPackage
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/README.md
+++ b/README.md
@@ -84,10 +84,16 @@ sudo apt install curl           # or your distro's equivalent
 
 ### 2. Clone
 
+The repo has private submodules. A plain clone works (the flake falls back to public stubs), but as the owner, init the submodules so the real identifiers load:
+
 ```bash
 cd ~/
-git clone https://github.com/QuinnHerden/.dotfiles.git
+git clone --recurse-submodules https://github.com/QuinnHerden/.dotfiles.git
+# or, after a plain clone:
+git submodule update --init
 ```
+
+Without the private overlay (`nix/private`), the NixOS rebuild scripts warn and fall back to an empty authorized-SSH-keys stub.
 
 ### 3. Init
 
@@ -114,6 +120,62 @@ Apply the config:
 ```bash
 sh ~/.dotfiles/files/scripts/.switch
 ```
+
+## Add a machine
+
+Hosts are data. Each machine is an entry in the `hosts` attrset in `nix/flake.nix`, mapped through `mkHost`. Adding a machine means adding an entry plus its host directory; you never copy a builder block.
+
+Generic starting points live in `nix/hosts/_template/`, one directory per platform (each holds a `default.nix`, so copying the directory needs no rename):
+
+| Directory | For |
+|------|-----|
+| `nixos/` (`default.nix` + `hardware-configuration.nix`) | A NixOS host |
+| `darwin/` | A nix-darwin host |
+| `home/` | A standalone home-manager host |
+
+### NixOS host
+
+1. Copy `nix/hosts/_template/nixos/` to `nix/hosts/<name>/`.
+2. Replace the stub hardware config with real output:
+   ```bash
+   nixos-generate-config --show-hardware-config > nix/hosts/<name>/hardware-configuration.nix
+   ```
+3. In `nix/hosts/<name>/default.nix`, set `hostname.name` and the package toggles.
+4. Add an entry under `hosts.nixos` in `nix/flake.nix`:
+   ```nix
+   <name> = {
+     builder = "nixos";
+     hostPath = ./hosts/<name>;
+   };
+   ```
+5. Set the system hostname to `<name>` (see step 4 of the install runbook).
+6. Switch:
+   ```bash
+   sh ~/.dotfiles/files/scripts/.switch
+   ```
+
+### Darwin host
+
+Copy `nix/hosts/_template/darwin/` to `nix/hosts/<name>/`, then add an entry under `hosts.darwin` with `builder = "darwin"` and `hostPath = ./hosts/<name>`.
+
+### Standalone home-manager host
+
+Copy `nix/hosts/_template/home/` to `nix/hosts/<name>/`, set `home.username` and `home.homeDirectory` in its `default.nix`, then add an entry under `hosts.home` with `builder = "home"`, the right `system` (e.g. `aarch64-linux`), and `hostPath = ./hosts/<name>`.
+
+**Caveat:** the username is still hardcoded to `quinnherden` in the nixos and darwin system modules. Full username parameterization is a tracked follow-up. The home template is fully generic.
+
+## Fork this
+
+The public flake evaluates and builds standalone, with no access to anything private. Real identifiers (such as the authorized SSH key) live in a private overlay behind `inputs.private`, which defaults to an in-repo public stub at `nix/private-stub`. CI and forks build against that stub.
+
+To supply your own last mile, pick one:
+
+- Edit the public modules directly.
+- Point `inputs.private` at your own overlay.
+
+The owner does the second: a private submodule at `nix/private`, plus an `--override-input private path:...` baked into the rebuild scripts. As a forker, ignore or deinit that submodule. The stub default keeps the flake evaluatable.
+
+The template hosts (`hosts.nixos.template`, `hosts.darwin.template`, `hosts.home.template`) are built in CI to guarantee the public layer stays forkable.
 
 ## Dev Containers
 

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -106,6 +106,9 @@
           };
 
       # The host matrix. Adding a machine is an entry here plus its host dir.
+      # The `template` entries are generic, forkable examples (see hosts/_template)
+      # that CI builds to keep the public layer evaluatable without the private
+      # overlay.
       hosts = {
         nixos = {
           nix-box = {
@@ -116,12 +119,20 @@
             builder = "nixos";
             hostPath = ./hosts/nix-dots;
           };
+          template = {
+            builder = "nixos";
+            hostPath = ./hosts/_template/nixos;
+          };
         };
         # Docs: https://daiderd.com/nix-darwin/manual/index.html
         darwin = {
           mac-papi = {
             builder = "darwin";
             hostPath = ./hosts/mac-papi;
+          };
+          template = {
+            builder = "darwin";
+            hostPath = ./hosts/_template/darwin;
           };
         };
         home = {
@@ -134,6 +145,11 @@
             builder = "home";
             system = "aarch64-linux";
             hostPath = ./hosts/dev-container;
+          };
+          template = {
+            builder = "home";
+            system = "aarch64-linux";
+            hostPath = ./hosts/_template/home;
           };
         };
       };

--- a/nix/hosts/_template/darwin/default.nix
+++ b/nix/hosts/_template/darwin/default.nix
@@ -1,0 +1,38 @@
+# Generic nix-darwin template. To add a machine:
+#   1. Copy this directory to hosts/<name>/.
+#   2. Set hostname.name and the package-category toggles below.
+#   3. Add an entry under hosts.darwin in flake.nix.
+# Note: the user is still quinnherden (system.primaryUser in darwinSystem.nix);
+# full username parameterization is a tracked follow-up to #148.
+{ pkgs, ... }:
+
+{
+  system.stateVersion = 4; # $ darwin-rebuild changelog
+  nixpkgs.hostPlatform = "aarch64-darwin";
+
+  hostname = {
+    enable = true;
+    name = "template-darwin";
+  };
+
+  users.users.quinnherden = {
+    name = "quinnherden";
+    home = "/Users/quinnherden";
+
+    shell = pkgs.zsh;
+  };
+
+  commonBaseHome = {
+    enable = true;
+    name = "quinnherden";
+  };
+  darwinBaseHome = {
+    enable = true;
+    name = "quinnherden";
+  };
+
+  ############
+  # packages #
+  ############
+  opsPackages.enable = true;
+}

--- a/nix/hosts/_template/home/default.nix
+++ b/nix/hosts/_template/home/default.nix
@@ -1,0 +1,19 @@
+# Generic standalone home-manager template (no NixOS/nix-darwin system layer).
+# To add a target:
+#   1. Copy this directory to hosts/<name>/.
+#   2. Set home.username and home.homeDirectory.
+#   3. Add an entry under hosts.home in flake.nix (with the right system).
+# The home modules are username-parameterized, so this template is fully generic.
+_:
+
+{
+  imports = [ ../../../modules/home/content/linux.nix ];
+
+  home.username = "template";
+  home.homeDirectory = "/home/template";
+
+  ############
+  # packages #
+  ############
+  opsPackages.enable = true;
+}

--- a/nix/hosts/_template/nixos/default.nix
+++ b/nix/hosts/_template/nixos/default.nix
@@ -1,0 +1,22 @@
+# Generic NixOS workstation template. To add a machine:
+#   1. Copy this directory to hosts/<name>/.
+#   2. Replace hardware-configuration.nix with `nixos-generate-config` output.
+#   3. Set hostname.name and the package-category toggles below.
+#   4. Add an entry under hosts.nixos in flake.nix.
+# Note: the user is still quinnherden (from the shared base); full username
+# parameterization is a tracked follow-up to #148.
+_:
+
+{
+  imports = [
+    ./hardware-configuration.nix
+    ../../_shared/nixos-workstation.nix
+  ];
+
+  hostname.name = "template-nixos";
+
+  ############
+  # packages #
+  ############
+  opsPackages.enable = true;
+}

--- a/nix/hosts/_template/nixos/hardware-configuration.nix
+++ b/nix/hosts/_template/nixos/hardware-configuration.nix
@@ -1,0 +1,22 @@
+# STUB hardware config for the template NixOS host. NOT bootable, it only lets
+# the template evaluate and build in CI. On a real machine, replace this file
+# with the output of `nixos-generate-config --show-hardware-config`.
+{ lib, modulesPath, ... }:
+
+{
+  imports = [ (modulesPath + "/installer/scan/not-detected.nix") ];
+
+  fileSystems."/" = {
+    device = "/dev/disk/by-label/nixos";
+    fsType = "ext4";
+  };
+
+  fileSystems."/boot" = {
+    device = "/dev/disk/by-label/boot";
+    fsType = "vfat";
+  };
+
+  swapDevices = [ ];
+
+  nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
+}


### PR DESCRIPTION
Closes #148. Final part of the forkable-flake work.

## What
- **Generic template hosts** at `nix/hosts/_template/{nixos,darwin,home}/`, each a self-contained directory mirroring a real host so "add a machine" is a literal directory copy (no rename). The nixos template ships a stub `hardware-configuration.nix`.
- **Wired into the `hosts` matrix**; CI builds the **nixos** and **home** templates. The **darwin** template is eval-only (`flake check --all-systems`) since its build path is already covered by `mac-papi` and a second macOS build is redundant.
- **README**: clone note (submodule init), `## Add a machine`, `## Fork this` (docs via technical-writer).

## Verification
- All three templates evaluate; the home template builds; `flake check` evaluates every output for every system.
- Real hosts (`nix-box`, `mac-papi`) are **byte-identical to main** — templates don't touch them.
- Lint passes.

## Review fixes applied
- Per-platform **subdirectories** (not flat files), so templates use the same `hostPath = ./hosts/_template/<platform>` dir shape as real hosts and the README copy step is mechanical (caught by code-reviewer + architect).
- Darwin template **build dropped to eval-only** to avoid a redundant costly macOS build (architect).
- README NixOS step reworded to copy the directory (avoids a forker landing on a broken `hostPath`).

## Note
Username stays `quinnherden` in the nixos/darwin system modules (`quinnherdenUser`, `system.primaryUser`); the home template is fully generic. Full username parameterization is the remaining follow-up, intentionally out of #148's scope.

## #148 summary (all merged)
mkHost builder (#167) → dead VPN delete (#168) → knowledge rename (#169) → public/private seam (#170) → these templates + docs.