### PR TITLE
Install GUI + heavy packages on NixOS desktops (opsPackages)

### DIFF
--- a/nix/modules/system/nixos/packages/opsPackages.nix
+++ b/nix/modules/system/nixos/packages/opsPackages.nix
@@ -11,11 +11,27 @@ in
 
 {
 
-  options.opsPackages.enable = lib.mkEnableOption "enables opsPackages";
+  options.opsPackages = {
+    enable = lib.mkEnableOption "enables opsPackages";
+    enableGui = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Include GUI/desktop packages (disable for headless environments)";
+    };
+    enableHeavy = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Include heavy tools like ffmpeg, ollama, pandoc (disable for lightweight environments)";
+    };
+  };
 
   config = lib.mkIf config.opsPackages.enable {
     environment.systemPackages =
-      (pkg.common pkgs) ++ (pkg.linux pkgs) ++ (lib.optionals pkgs.stdenv.isx86_64 (pkg.linuxX86 pkgs));
+      (pkg.common pkgs)
+      ++ (pkg.linux pkgs)
+      ++ (lib.optionals pkgs.stdenv.isx86_64 (pkg.linuxX86 pkgs))
+      ++ (lib.optionals config.opsPackages.enableHeavy (pkg.heavy pkgs))
+      ++ (lib.optionals config.opsPackages.enableGui (pkg.linuxGui pkgs));
   };
 
 }


### PR DESCRIPTION
## Problem
The NixOS `opsPackages` module (`nix/modules/system/nixos/packages/opsPackages.nix`) installed only `common ++ linux ++ linuxX86`. It never pulled **`linuxGui`** (alacritty, rofi, brave, qutebrowser, obsidian, feh, brightnessctl, bitwarden) or **`heavy`**. Those lists were only wired into the *standalone* home-manager `opsPackages` module (dev-container/kali-bug).

Result: `nix-box` and `nix-dots` (NixOS i3 desktops) install **no terminal emulator and no launcher**. A freshly switched desktop has no usable GUI — `command -v alacritty` is empty, `$mod+Return` gives nothing. (Pre-existing gap from the package-simplify refactor; surfaced when nix-dots was switched for the first time since.)

## Fix
Mirror the standalone module in the NixOS one:
- Add `opsPackages.enableGui` and `opsPackages.enableHeavy` options (default `true`).
- Pull `pkg.heavy` and `pkg.linuxGui` accordingly.

Headless NixOS hosts can set `enableGui`/`enableHeavy = false`.

## Verification
With this change, `nix-dots` and `nix-box` `environment.systemPackages` now include `alacritty`, `rofi`, `brave`, `qutebrowser`, `obsidian`, `feh` (verified via `nix eval`). Lint passes.

## Context
This is the root cause of the "new terminal hangs / no working terminal after switching nix-dots to main" investigation. Separate, still-open items from that thread:
- SSH-only-over-tailscale is #118 working as designed (port 22 closed on LAN).
- u2f sudo needs its authfile path pinned (sudo falls through to password, not a lockout) — tracked separately.