### PR TITLE
fix(nixos): give the fork template a bootstrap login path (#176)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,25 @@ jobs:
       - name: pre-commit (all files)
         run: nix develop ./nix --command pre-commit run --all-files --show-diff-on-failure
 
+  # The template host (hosts/_template) ships a placeholder bootstrap password
+  # so a fresh fork can log in (see #176). This guard fails if that placeholder
+  # ever leaks into a real host config, so a fork that copies the template and
+  # forgets to change it cannot ship a known credential. Cheap and content-only,
+  # so it always runs (not gated on the nix/ filter).
+  placeholder-guard:
+    name: placeholder guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: no placeholder credential outside _template
+        run: |
+          if grep -rn 'changeme' nix/hosts --include='*.nix' \
+            | grep -v '^nix/hosts/_template/'; then
+            echo "placeholder bootstrap password found outside hosts/_template/ — change it before merging"
+            exit 1
+          fi
+          echo "no placeholder credential outside the template"
+
   # Builds run on PRs that touch nix/ (and on every push/dispatch). They are
   # gated by `changes` because only nix/ can affect a build output. The matrix
   # is cheap (~4 min wall-clock, parallel); the VM boot test below is the slow
@@ -158,18 +177,19 @@ jobs:
   ci-required:
     name: ci-required
     if: always()
-    needs: [flake-check, lint, build, nixos-vm-test]
+    needs: [flake-check, lint, placeholder-guard, build, nixos-vm-test]
     runs-on: ubuntu-latest
     steps:
       - name: gate
         env:
           R_FLAKE: ${{ needs.flake-check.result }}
           R_LINT: ${{ needs.lint.result }}
+          R_GUARD: ${{ needs.placeholder-guard.result }}
           R_BUILD: ${{ needs.build.result }}
           R_VM: ${{ needs.nixos-vm-test.result }}
         run: |
-          echo "flake-check=$R_FLAKE lint=$R_LINT build=$R_BUILD vm=$R_VM"
-          for r in "$R_FLAKE" "$R_LINT" "$R_BUILD" "$R_VM"; do
+          echo "flake-check=$R_FLAKE lint=$R_LINT guard=$R_GUARD build=$R_BUILD vm=$R_VM"
+          for r in "$R_FLAKE" "$R_LINT" "$R_GUARD" "$R_BUILD" "$R_VM"; do
             case "$r" in
               failure | cancelled)
                 echo "required job not green: $r"

--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ Generic starting points live in `nix/hosts/_template/`, one directory per platfo
    sh ~/.dotfiles/files/scripts/.switch
    ```
 
+> **Bootstrap login:** authorized SSH keys come from the owner's private overlay, which a fork does not have, so the template sets a placeholder `initialPassword` (`changeme`) on the primary user to keep a fresh build reachable on first boot. Change it before any real use: add your own SSH key via a private overlay, or replace it with a `hashedPassword` (`mkpasswd -m sha-512`). The owner's real hosts do not set it.
+
 ### Darwin host
 
 Copy `nix/hosts/_template/darwin/` to `nix/hosts/<name>/`, set `hostname.name` and `user.name`, then add an entry under `hosts.darwin` with `builder = "darwin"` and `hostPath = ./hosts/<name>`.

--- a/nix/hosts/_template/nixos/default.nix
+++ b/nix/hosts/_template/nixos/default.nix
@@ -3,7 +3,8 @@
 #   2. Replace hardware-configuration.nix with `nixos-generate-config` output.
 #   3. Set hostname.name and the package-category toggles below.
 #   4. Add an entry under hosts.nixos in flake.nix.
-_:
+#   5. Replace the bootstrap login below with your own SSH key or password.
+{ config, ... }:
 
 {
   imports = [
@@ -13,6 +14,15 @@ _:
 
   hostname.name = "template-nixos";
   user.name = "user";
+
+  # BOOTSTRAP LOGIN (placeholder) -- without this a fresh fork builds a host it
+  # cannot log into: the primary user has no password, and authorized SSH keys
+  # come from the owner's private overlay (inputs.private) that a fork lacks.
+  # `initialPassword` applies only at first user creation and is meant to be
+  # changed. CHANGE THIS before any real use: supply your own SSH key via a
+  # private overlay, or set `hashedPassword` (mkpasswd -m sha-512) instead.
+  # Do not ship this as-is. The owner's real hosts do not set this.
+  users.users.${config.user.name}.initialPassword = "changeme";
 
   ############
   # packages #


### PR DESCRIPTION
Closes #176.

## Problem
A fresh fork could build a NixOS host it cannot log into: the generic primary user has no password and no SSH key, and authorized keys come from the private overlay (`inputs.private`) a fork does not have.

## Change
- **Template host** (`hosts/_template/nixos/default.nix`): a clearly-marked placeholder `users.users.${config.user.name}.initialPassword = "changeme"`. References `user.name` so it tracks the single-source-of-truth `user` option. `initialPassword` applies only at first user creation (`mutableUsers` defaults true) and is loudly commented to change before real use.
- **CI guard** (`placeholder-guard`, wired into `ci-required`): fails if `changeme` ever appears outside `hosts/_template/`, so a fork that copies the template and forgets to change it cannot ship a known credential.
- **README**: documents the bootstrap login in the NixOS-host steps.

## Scope / safety
- Owner hosts unaffected: `nix-dots`/`nix-box` set no password (verified `nixosConfigurations.nix-dots…initialPassword` → `null`).
- Not remotely reachable: `PasswordAuthentication = false` and the firewall trusts only `tailscale0` (#118), so the placeholder is usable only at the console — the intended bootstrap path.

## Acceptance criteria
- [x] A fresh fork can log into a built NixOS host using only public-tree config (console: `user` / `changeme`).
- [x] Bootstrap credential clearly marked as a placeholder to change before real use.
- [x] No insecure *persistent* default: applies only at first creation, overridden by `passwd`, never re-applied on rebuild.
- [x] security-analyst signed off (no critical/high; SSH exposure ruled out). code-reviewer + sw-architect also reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)