### PR TITLE
fix(home): don't dangle ~/.claude/knowledge on a fork (#177)

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,14 @@ To supply your own last mile, pick one:
 - Edit the public modules directly.
 - Point `inputs.private` at your own overlay.
 
-The owner does the second: a single private submodule at `private/` (holding the overlay and the knowledge library), plus an `--override-input private path:...` baked into the rebuild scripts. As a forker, ignore or deinit that submodule. The stub default keeps the flake evaluatable.
+The owner does the second: a single private submodule at `private/` (holding the overlay and the knowledge library), plus an `--override-input private path:...` baked into the rebuild scripts. The stub default keeps the flake evaluatable, so a fork needs no submodule access.
+
+A fork cannot clone that private submodule (it is owner-only). A plain `git clone` (without `--recurse-submodules`) already leaves `private/` empty and builds clean against the stub; nothing dangles, because the `~/.claude/knowledge` link is created at activation only when `private/knowledge` is actually present. To drop the inherited submodule reference entirely:
+
+```bash
+git submodule deinit -f private && git rm -f private && rm -rf .git/modules/private
+git commit -m "drop private submodule"
+```
 
 The template hosts (`hosts.nixos.template`, `hosts.darwin.template`, `hosts.home.template`) are built in CI to guarantee the public layer stays forkable.
 

--- a/nix/modules/home/content/base.nix
+++ b/nix/modules/home/content/base.nix
@@ -35,8 +35,9 @@
       config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/.dotfiles/files/home/.claude/agents";
     ".claude/skills".source =
       config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/.dotfiles/files/home/.claude/skills";
-    ".claude/knowledge".source =
-      config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/.dotfiles/private/knowledge";
+    # .claude/knowledge is handled by the activation script below, not here: its
+    # source is the private/knowledge submodule, which a fork cannot clone, so an
+    # unconditional symlink would dangle (#177).
     ".claude/rules".source =
       config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/.dotfiles/files/home/.claude/rules";
     ".claude/output-styles".source =
@@ -56,6 +57,27 @@
       recursive = true;
     };
   };
+
+  # Link the private Claude knowledge library only when it is actually checked
+  # out. The source (private/knowledge) is a submodule a fork cannot clone, and
+  # it is an out-of-store path pure eval cannot stat, so the presence check has
+  # to run at activation: link when present, drop a stale link when absent (so a
+  # fork never gets a dangling ~/.claude/knowledge). #177. Honors
+  # $DRY_RUN_CMD/$VERBOSE_ARG so `home-manager switch --dry-run` stays read-only.
+  # A real directory at the target is left untouched in both branches, so a
+  # stale dir is never clobbered into a nested link nor deleted. Dev containers
+  # serve knowledge differently and are not handled here (see #181).
+  home.activation.claudeKnowledge = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    src="${config.home.homeDirectory}/.dotfiles/private/knowledge"
+    dst="${config.home.homeDirectory}/.claude/knowledge"
+    if [ -d "$dst" ] && [ ! -L "$dst" ]; then
+      echo "claude knowledge: $dst is a real directory, leaving it untouched" >&2
+    elif [ -e "$src" ]; then
+      $DRY_RUN_CMD ln -sfn $VERBOSE_ARG "$src" "$dst"
+    elif [ -L "$dst" ] || [ ! -e "$dst" ]; then
+      $DRY_RUN_CMD rm -f $VERBOSE_ARG "$dst"
+    fi
+  '';
 
   home.sessionPath = [
     "$HOME/.local/bin/"


### PR DESCRIPTION
Closes #177.

## Problem
The Claude knowledge library lives in the private submodule (`private/knowledge`), which a fork cannot clone (403). `base.nix` linked it with an unconditional `mkOutOfStoreSymlink`, so a fork's home-manager switch left a **dangling** `~/.claude/knowledge`.

## Change
- **`base.nix`**: replace the unconditional symlink with a home-manager activation script that links `private/knowledge → ~/.claude/knowledge` only when the source exists, and removes a stale link when absent. The presence check runs at activation because the submodule is an out-of-store path pure eval cannot stat. A real directory at the target is left untouched in both branches (never clobbered into a nested link nor deleted). Honors `$DRY_RUN_CMD`/`$VERBOSE_ARG` so `--dry-run` stays read-only.
- **README**: documents that a plain clone builds clean against the stub (nothing dangles) and gives a one-step submodule-removal command.

## Notes
- `.gitmodules` already holds a **single** private submodule (consolidated in #174), so the two-submodule scenario described in the issue no longer applies.
- Review surfaced a separate gap — dev containers never link knowledge into `CLAUDE_CONFIG_DIR` — filed as #181, not overloaded into this fix.

## Acceptance criteria
- [x] Documented one-step path to remove/repoint the private submodule.
- [x] `~/.claude/knowledge` does not dangle when the target is absent (self-heals at activation).
- [x] A plain clone of a fork reaches a clean home-manager switch without manual cleanup.
- [x] Cross-referenced with #174.

## Verification
- `nix build .#homeConfigurations.template.activationPackage` succeeds; generated script linked/cleanup branches confirmed by eval.
- Reviewed by sw-architect (approach: activation script over option-toggle, given the container's runtime-variable submodule presence), code-reviewer, and security-analyst (no private content enters the store; file ops safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)