### PR TITLE
fix(container): cache layers correctly and pin the dev image (#125)

### DIFF
--- a/.containerignore
+++ b/.containerignore
@@ -1,0 +1,24 @@
+# Build context for the dev container is the repo root (see files/scripts/dev).
+# Excluded so the image stays stub-based and secret-free, and so layer caching
+# keys on real source changes only:
+#   - private/ : the private submodule (SSH overlay + knowledge library). The
+#     container builds against the public stub (inputs.private); never bake the
+#     private overlay or its SSH key into the image.
+#   - .git/    : large and changes on every commit, which would bust the COPY
+#     layer (and the Nix layers below it) regardless of what actually changed.
+.git
+private
+
+# Nix build result symlinks, if any are lying around in the working tree.
+result
+result-*
+
+# Deny-by-default for secret-shaped files so nothing sensitive is ever baked
+# into a layer, even if it appears in the working tree later (the image is built
+# from the live tree, not a clean clone). None exist today; this is insurance.
+**/.env
+**/*.pem
+**/*.key
+**/id_rsa*
+**/id_ed25519*
+**/.ssh/

--- a/container/Containerfile
+++ b/container/Containerfile
@@ -1,5 +1,10 @@
 FROM debian:bookworm-slim AS base
 
+# Pinned tool versions (bump deliberately; do not float). The debian base could
+# additionally be digest-pinned (FROM debian:bookworm-slim@sha256:...) for
+# stricter reproducibility. See #125.
+ARG PODMAN_COMPOSE_VERSION=1.6.0
+
 # System dependencies for Nix and dev tooling
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
@@ -9,7 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     sudo \
     jq \
     python3-pip \
-    && pip3 install --break-system-packages podman-compose \
+    && pip3 install --break-system-packages "podman-compose==${PODMAN_COMPOSE_VERSION}" \
     && rm -rf /var/lib/apt/lists/*
 
 # Create dev user
@@ -19,14 +24,11 @@ RUN useradd -m -s /bin/bash dev \
 USER dev
 WORKDIR /home/dev
 
-# --- Install Nix (single-user) ---
-RUN curl -L https://nixos.org/nix/install | sh -s -- --no-daemon
-
-# --- Clone dotfiles and cache nixpkgs download ---
-ARG DOTFILES_REPO=https://github.com/QuinnHerden/.dotfiles.git
-ARG DOTFILES_BRANCH=main
-
-RUN git clone --branch ${DOTFILES_BRANCH} ${DOTFILES_REPO} /home/dev/.dotfiles
+# --- Install Nix (single-user), pinned to a specific release ---
+ARG NIX_VERSION=2.34.7
+RUN curl -fsSL "https://releases.nixos.org/nix/nix-${NIX_VERSION}/install" -o /tmp/nix-install \
+    && sh /tmp/nix-install --no-daemon \
+    && rm /tmp/nix-install
 
 ENV PATH="/home/dev/.npm-global/bin:/home/dev/.local/bin:/home/dev/.nix-profile/bin:${PATH}" \
     NPM_CONFIG_PREFIX=/home/dev/.npm-global \
@@ -39,11 +41,30 @@ ENV PATH="/home/dev/.npm-global/bin:/home/dev/.local/bin:/home/dev/.nix-profile/
 RUN mkdir -p /home/dev/.config/nix \
     && echo "experimental-features = nix-command flakes" > /home/dev/.config/nix/nix.conf
 
-# Pre-fetch flake inputs (big download — cached in this layer if flake.lock unchanged)
+# --- Pre-fetch flake inputs (the big download) ---
+# Copy only what `nix flake archive` needs to resolve inputs: the lockfile, the
+# flake, and the path: inputs it references (private-stub). This layer therefore
+# caches on flake.lock and is not invalidated by unrelated dotfiles changes.
+COPY --chown=dev:dev nix/flake.nix nix/flake.lock /home/dev/.dotfiles/nix/
+COPY --chown=dev:dev nix/private-stub /home/dev/.dotfiles/nix/private-stub
 RUN cd /home/dev/.dotfiles/nix && nix flake archive --no-write-lock-file
 
-# --- Run home-manager switch ---
-RUN nix run nixpkgs#home-manager -- switch --flake /home/dev/.dotfiles/nix#dev@dev-container
+# --- Build + activate home-manager from the LOCKED flake input ---
+# home-manager depends only on nix/** (the files/ entries are runtime
+# mkOutOfStoreSymlink targets, not build inputs), so copy just nix/ and activate
+# before the rest of the tree. A README/agent/files change then busts only the
+# final COPY below, not this expensive layer. Uses the flake's locked
+# home-manager input, not a floating `nix run nixpkgs#home-manager`.
+COPY --chown=dev:dev nix /home/dev/.dotfiles/nix
+RUN set -eu; cd /home/dev/.dotfiles/nix \
+    && out=$(nix build --no-link --print-out-paths '.#homeConfigurations."dev@dev-container".activationPackage') \
+    && "$out/activate"
+
+# --- Copy the rest of the dotfiles tree (private/ and .git excluded; see
+# .containerignore). These are the runtime symlink targets and do not affect the
+# home-manager build above. This re-copies nix/ too (already placed above);
+# that is harmless and keeps the final tree a faithful copy of the repo. ---
+COPY --chown=dev:dev . /home/dev/.dotfiles
 
 # --- Docker/Podman CLI alias for Makefile compatibility ---
 # CONTAINER_HOST env var tells podman to use the mounted socket
@@ -52,7 +73,7 @@ RUN mkdir -p /home/dev/.local/bin \
     && chmod +x /home/dev/.local/bin/docker
 
 # --- Entrypoint ---
-COPY --chown=dev:dev entrypoint.sh /home/dev/entrypoint.sh
+COPY --chown=dev:dev container/entrypoint.sh /home/dev/entrypoint.sh
 RUN chmod +x /home/dev/entrypoint.sh
 
 WORKDIR /home/dev

--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -66,6 +66,9 @@ else
 fi
 
 # Install/repair Claude Code (runtime install — cached via npm prefix volume).
+# Intentionally tracks @latest (#125): Claude Code ships frequently and we want
+# the newest CLI, so the image is deliberately not a frozen artifact for this one
+# component (the Nix toolchain is pinned). Bump by restarting the container.
 # claude-code ships a JS stub plus a platform-native optional dependency that is
 # fetched by its postinstall; an interrupted or optional-omitting install leaves
 # `claude` on PATH but non-functional. So verify it actually *runs* (not just

--- a/files/scripts/dev
+++ b/files/scripts/dev
@@ -91,9 +91,14 @@ if [ "${DEV_DOCKER_SOCK:-}" = "1" ] && [ -n "$PODMAN_SOCKET" ]; then
 fi
 
 # --- Build image ---
+# Context is the repo root so the Containerfile can COPY the dotfiles tree (see
+# .containerignore for what is excluded). Layer caching is left on: the COPY
+# layers are content-addressed, so the expensive Nix layers only re-run when
+# nix/flake.lock changes, not on every dotfiles commit. Force a clean rebuild
+# with: podman build --no-cache -t dev-container -f container/Containerfile .
 build_image() {
   echo "Building dev container image..."
-  podman build --no-cache -t "$IMAGE_NAME" -f "$HOME/.dotfiles/container/Containerfile" "$HOME/.dotfiles/container/"
+  podman build -t "$IMAGE_NAME" -f "$HOME/.dotfiles/container/Containerfile" "$HOME/.dotfiles/"
 }
 
 ensure_image() {


### PR DESCRIPTION
Closes #125.

## Problem
The Containerfile cloned the repo inside the build and ran with `--no-cache`, so every dotfiles commit re-ran the multi-minute `nix flake archive` and `home-manager` layers, and several inputs floated (unpinned Nix installer, floating `nix run nixpkgs#home-manager`, unpinned podman-compose).

## Change
- **Content-addressed `COPY`** (build context = repo root) ordered by the real dependency graph:
  1. copy `flake.nix` + `flake.lock` + `private-stub` → `nix flake archive` (caches on `flake.lock`),
  2. copy `nix/` → build+activate home-manager (caches on `nix/**`),
  3. copy the rest of the tree (runtime `mkOutOfStoreSymlink` targets).
  A README/agent/`files/` edit now busts only the final cheap layer.
- **Locked home-manager**: build `homeConfigurations."dev@dev-container".activationPackage` and run its `activate`, instead of floating `nix run nixpkgs#home-manager`.
- **Pins**: Nix installer → versioned release `nix-2.34.7`; `podman-compose==1.6.0`.
- **Launcher** (`files/scripts/dev`): drop `--no-cache`, context → repo root; documented the clean-rebuild escape hatch.
- **`.containerignore`** (new): excludes `.git` and `private/` (image stays stub-based + secret-free) plus a secret-shaped denylist as insurance.
- **`@latest` Claude Code**: recorded as an intentional, documented choice.

## Acceptance criteria
- [x] A README-only change does not re-run the flake archive or home-manager layers (layer split; home-manager keyed on `nix/**` only).
- [x] Nix installer pinned to a version (`nix-2.34.7`). *(checksum: deferred — `releases.nixos.org` is unreachable from the authoring env; one-line follow-up below.)*
- [x] Build-time home-manager comes from the locked flake input.
- [x] The misleading caching comment is removed/corrected.
- [x] Decision recorded on `claude-code@latest` (kept floating, intentional).

## Notes / deferred (optional)
- **Nix installer sha256** and **debian base digest** pins need values from a networked host (those hosts 405 from my environment). Both are optional in the issue; happy to add the installer checksum as a 1-line follow-up — just need `curl -fsSL https://releases.nixos.org/nix/nix-2.34.7/install | sha256sum`.
- The image build is **not** exercised in CI (no container build job); validate with `dev --rebuild` on the workstation.

Reviewed by code-reviewer, system-architect, security-analyst — no critical/high. `nix flake archive` on the partial tree verified locally (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)