### PR TITLE
fix(container): make the knowledge library available in dev containers (#181)

### DIFF
--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -47,6 +47,20 @@ if [ -d /home/dev/.claude-memory ]; then
   ln -sfn /home/dev/.claude-memory "$CCDIR/memory"
 fi
 
+# Claude knowledge library, mounted read-only from the host's private submodule
+# (see the dev launcher). The agents reference ~/.claude/knowledge by literal
+# path, while Claude reads its config from CLAUDE_CONFIG_DIR, so link it into
+# both. Skipped when the mount is absent (e.g. a fork without the submodule).
+# ~/.claude/knowledge is unmanaged by home-manager since #177; if it is ever
+# re-added to home.file, this rm -rf would clobber the managed copy.
+if [ -d /home/dev/.claude-knowledge ]; then
+  for kdst in "$HOME/.claude/knowledge" "${CCDIR:?}/knowledge"; do
+    mkdir -p "$(dirname "$kdst")"
+    rm -rf "$kdst"
+    ln -sfn /home/dev/.claude-knowledge "$kdst"
+  done
+fi
+
 # Persist gh CLI auth in the per-container state so it survives recreation. git
 # uses `gh auth git-credential`, so this fixes git auth too.
 if [ -d /home/dev/.dev-state ]; then

--- a/files/scripts/dev
+++ b/files/scripts/dev
@@ -179,6 +179,14 @@ chmod 700 "$DEV_STATE"
 # isolating it per container. Per-project memory lives under projects/ instead.
 mkdir -p "${HOME}/.claude/memory"
 
+# Claude knowledge library lives in the private submodule on the host. Mount it
+# read-only so the in-container Claude can read it; skipped if not checked out
+# (e.g. a fork without the private submodule). The entrypoint links it in.
+knowledge_mount=()
+if [ -d "${HOME}/.dotfiles/private/knowledge" ]; then
+  knowledge_mount=(-v "${HOME}/.dotfiles/private/knowledge:/home/dev/.claude-knowledge:ro")
+fi
+
 ensure_image
 
 echo "Starting container '$NAME'..."
@@ -191,6 +199,7 @@ podman run -d \
   "${mount_env[@]}" \
   -v "${DEV_STATE}:/home/dev/.dev-state" \
   -v "${HOME}/.claude/memory:/home/dev/.claude-memory" \
+  "${knowledge_mount[@]}" \
   -v "npm-cache-${NAME}:/home/dev/.npm" \
   -e DEV_DETACHED=1 \
   "$IMAGE_NAME"


### PR DESCRIPTION
Closes #181.

## Problem
Dev containers had no access to the Claude knowledge library. It lives in the private submodule (not copied into the image — `.containerignore` excludes `private/`), and the entrypoint mirrored only `files/home/.claude/*` and `memory` into the config dir. So `~/.claude/knowledge/...` references in the agents didn't resolve inside a container.

## Change
- **`files/scripts/dev`**: mount the host's `~/.dotfiles/private/knowledge` read-only into the container (`/home/dev/.claude-knowledge`), conditional on it being checked out (a fork without the submodule gets no mount, no error). Mirrors the existing `socket_mount`/memory pattern.
- **`container/entrypoint.sh`**: if the mount is present, link it into both `~/.claude/knowledge` (the literal path agents reference) and `$CLAUDE_CONFIG_DIR/knowledge` (where Claude reads config).

## Notes
- Private content stays a **runtime read-only mount** — never baked into the image (seam preserved; `.containerignore` still excludes `private/`).
- Knowledge is unmanaged by home-manager since #177, so the entrypoint owning `~/.claude/knowledge` doesn't conflict (noted in a comment).
- Reviewed by code-reviewer + security-analyst (no findings).
- The container can't be built/run in CI; validate with `dev --rebuild` + `dev work ~/repos` then check `~/.claude/knowledge` resolves inside.

## Acceptance criteria
- [x] Inside a dev container, knowledge resolves where Claude reads it (both `~/.claude/knowledge` and `$CLAUDE_CONFIG_DIR/knowledge`).
- [x] A container without the private submodule is unaffected (no broken link).

🤖 Generated with [Claude Code](https://claude.com/claude-code)