### PR TITLE
chore: low-priority hardening + docs (#158, #121, #129)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,5 @@ files/config/karabiner/automatic_backups/
 lazy-lock.json
 
 # SSH
-.ssh/id_rsa*
+.ssh/id_*
 .ssh/known_hosts*

--- a/files/home/.gitconfig
+++ b/files/home/.gitconfig
@@ -7,9 +7,10 @@
 [safe]
 	# Allow git/nix-flake operations on the dotfiles clone inside dev containers
 	# (built as one uid, run under --userns=keep-id). Harmless where the path
-	# does not exist.
+	# does not exist. Scoped to this one path on purpose: a `*` wildcard would
+	# globally disable git's dubious-ownership protection (the mitigation for
+	# CVE-2022-24765).
 	directory = /home/dev/.dotfiles
-	directory = *
 [color]
 	ui = auto
 [pull]

--- a/nix/modules/home/standalone/devPackages.nix
+++ b/nix/modules/home/standalone/devPackages.nix
@@ -11,6 +11,9 @@ in
 
 {
 
+  # Scope: USER. Installs into home.packages (home-manager). The identically
+  # named NixOS module installs into environment.systemPackages instead; the two
+  # never coexist on one host. See #129.
   options.devPackages.enable = lib.mkEnableOption "enables devPackages";
 
   config = lib.mkIf config.devPackages.enable {

--- a/nix/modules/system/nixos/packages/devPackages.nix
+++ b/nix/modules/system/nixos/packages/devPackages.nix
@@ -11,6 +11,9 @@ in
 
 {
 
+  # Scope: SYSTEM. Installs into environment.systemPackages. The identically
+  # named home-manager module installs into home.packages instead; the two never
+  # coexist on one host. See #129.
   options.devPackages.enable = lib.mkEnableOption "enables devPackages";
 
   config = lib.mkIf config.devPackages.enable {


### PR DESCRIPTION
Closes #158, closes #121, closes #129.

Three trivial, low-risk changes batched.

## #158 — broaden SSH key gitignore
`.ssh/id_rsa*` → `.ssh/id_*`, so ed25519/ecdsa/dsa private keys (and `.pub`) are ignored too. Preventive — no SSH keys are tracked. Verified with `git check-ignore` (ed25519/ecdsa/dsa/rsa all ignored).

## #121 — narrow the git safe.directory wildcard
Dropped `safe.directory = *` (it globally disabled git's dubious-ownership protection, the CVE-2022-24765 mitigation), kept the explicit `/home/dev/.dotfiles`. The container case is covered by the explicit path; under `--userns=keep-id` mounted host repos are ownership-matched and need no exemption. Verified this clone's owner uid matches the current uid (wildcard not load-bearing).

## #129 — document devPackages.enable scope
Added a comment above `options.devPackages.enable` in both modules noting the USER (`home.packages`) vs SYSTEM (`environment.systemPackages`) scope split; the two never coexist on one host. Doc-only.

Reviewed by code-reviewer + security-analyst — no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)