### PR TITLE
refactor: parameterize residual owner-specific config (#175)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # OWNER HOSTS — replace these with your own hosts when you fork.
           - name: nix-dots (x86_64-linux)
             os: ubuntu-latest
             attr: nixosConfigurations.nix-dots.config.system.build.toplevel
@@ -124,10 +125,11 @@ jobs:
           - name: mac-papi (aarch64-darwin)
             os: macos-latest
             attr: darwinConfigurations.mac-papi.system
-          # Generic forkable templates (hosts/_template). Built so the public
-          # layer is provably buildable without the private overlay. The darwin
-          # template is eval-only (flake check --all-systems) since its build
-          # path is already covered by mac-papi on the costly macOS runner.
+          # KEEP THESE — generic forkable templates (nix/hosts/_template). They
+          # prove the public layer builds without the private overlay, so a fork
+          # should keep them even after replacing the owner hosts above. The
+          # darwin template is eval-only (flake check --all-systems) since its
+          # build path is already covered by mac-papi on the costly macOS runner.
           - name: template nixos (x86_64-linux)
             os: ubuntu-latest
             attr: nixosConfigurations.template.config.system.build.toplevel

--- a/README.md
+++ b/README.md
@@ -186,6 +186,14 @@ git commit -m "drop private submodule"
 
 The template hosts (`hosts.nixos.template`, `hosts.darwin.template`, `hosts.home.template`) are built in CI to guarantee the public layer stays forkable.
 
+### Residual owner-specific values
+
+A few things still carry the owner's identity or preferences; change them when you fork:
+
+- **CI build matrix** (`.github/workflows/ci.yml`): replace the owner-host entries (marked `OWNER HOSTS`) with your own. Keep the `template *` entries (marked `KEEP THESE`) — they are the check that proves your fork still builds standalone.
+- **iTerm2 profile** (`files/home/iterm2/profile.json`): the profile `Name` is `quinnherden` and a `Working Directory` path is the owner's home (inert, since `Custom Directory` is `No`). Edit if you import this profile.
+- **Timezone**: set `time.timeZone` per host (the templates default to `UTC`).
+
 ## Dev Containers
 
 Isolated dev environments using Podman. Each container gets the full dotfiles toolchain (zsh, nvim, lazygit, lazydocker, Claude Code) via Nix + home-manager.

--- a/files/config/qutebrowser/config.py
+++ b/files/config/qutebrowser/config.py
@@ -13,6 +13,11 @@
 # Change the argument to True to still load settings configured via autoconfig.yml
 config.load_autoconfig(False)
 
+# Userscripts dir, derived from the running user's home so this config is
+# portable across machines and platforms (was a hardcoded /Users/<owner> path).
+import os
+_userscripts = 'file://' + os.path.expanduser('~/.local/share/qutebrowser/userscripts/*')
+
 # Which cookies to accept. With QtWebEngine, this setting also controls
 # other features with tracking capabilities similar to those of cookies;
 # including IndexedDB, DOM storage, filesystem API, service workers, and
@@ -126,11 +131,11 @@ config.set('content.javascript.enabled', True, 'qute://*/*')
 
 # Allow locally loaded documents to access remote URLs.
 # Type: Bool
-config.set('content.local_content_can_access_remote_urls', True, 'file:///Users/quinnherden/.local/share/qutebrowser/userscripts/*')
+config.set('content.local_content_can_access_remote_urls', True, _userscripts)
 
 # Allow locally loaded documents to access other local URLs.
 # Type: Bool
-config.set('content.local_content_can_access_file_urls', False, 'file:///Users/quinnherden/.local/share/qutebrowser/userscripts/*')
+config.set('content.local_content_can_access_file_urls', False, _userscripts)
 
 # Render all web contents using a dark theme. On QtWebEngine < 6.7, this
 # setting requires a restart and does not support URL patterns, only the

--- a/nix/hosts/_template/darwin/default.nix
+++ b/nix/hosts/_template/darwin/default.nix
@@ -1,12 +1,14 @@
 # Generic nix-darwin template. To add a machine:
 #   1. Copy this directory to hosts/<name>/.
-#   2. Set hostname.name, user.name, and the package-category toggles below.
+#   2. Set hostname.name, user.name, time.timeZone, and the package toggles.
 #   3. Add an entry under hosts.darwin in flake.nix.
 _:
 
 {
   system.stateVersion = 4; # $ darwin-rebuild changelog
   nixpkgs.hostPlatform = "aarch64-darwin";
+
+  time.timeZone = "UTC"; # change to your timezone, e.g. "America/New_York"
 
   hostname = {
     enable = true;

--- a/nix/hosts/mac-papi/default.nix
+++ b/nix/hosts/mac-papi/default.nix
@@ -4,6 +4,8 @@ _:
   system.stateVersion = 4; # $ darwin-rebuild changelog
   nixpkgs.hostPlatform = "aarch64-darwin";
 
+  time.timeZone = "America/New_York";
+
   hostname = {
     enable = true;
     name = "mac-papi";

--- a/nix/modules/system/darwin/system/darwinSystem.nix
+++ b/nix/modules/system/darwin/system/darwinSystem.nix
@@ -21,8 +21,6 @@
 
     security.pki.certificateFiles = [ ];
 
-    time.timeZone = "America/New_York";
-
     system.defaults.loginwindow = {
       # allow guest user account
       GuestEnabled = false;


### PR DESCRIPTION
Closes #175.

After #148/#172 the tree is structurally forkable, but a few owner values still leaked into shared/inherited config. Scope validated by system-architect.

## Changes
- **Timezone**: removed the hardcoded `time.timeZone = "America/New_York"` from the shared darwin module; `mac-papi` sets it per-host, the darwin template defaults to `UTC` with a change-this note. No shared opinion remains.
- **qutebrowser**: derive the userscripts URL from the running user's home (`os.path.expanduser`) instead of a hardcoded `/Users/<owner>` path. Also a **bug fix** — that macOS path was wrong on Linux, the only platform that symlinks this config.
- **CI matrix**: labeled `OWNER HOSTS` (replace on fork) vs `KEEP THESE` (the template builds that prove standalone forkability), so a fork doesn't delete the guarantee.
- **README**: a "Residual owner-specific values" subsection documenting what a fork changes (CI matrix, the inert/cosmetic iTerm2 identifiers, per-host timezone).

The `quinnherden` literals in the owner's own host files and VM-test assertions are by design (forks use `hosts/_template/*`), left as-is.

## Acceptance criteria
- [x] Timezone set per host, not hardcoded in `darwinSystem.nix`.
- [x] qutebrowser path parameterized (iTerm2 documented — JSON, inert/cosmetic values).
- [x] CI matrix marks owner vs template entries; README states a fork edits it.
- [x] No `quinnherden`/`America/New_York` literal remains in shared/public config without a change-this note.

## Verification
- `darwinConfigurations.mac-papi.config.time.timeZone` → `America/New_York`; `...template...` → `UTC`.
- qutebrowser config passes `ast.parse`; no `/Users/quinnherden` left in it.
- Reviewed by code-reviewer + security-analyst (no findings; qutebrowser security posture unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)