### PR TITLE
fix(container): gate CONTAINER_HOST to the opt-in socket mount (#191)

### DIFF
--- a/container/Containerfile
+++ b/container/Containerfile
@@ -30,9 +30,12 @@ RUN curl -fsSL "https://releases.nixos.org/nix/nix-${NIX_VERSION}/install" -o /t
     && sh /tmp/nix-install --no-daemon \
     && rm /tmp/nix-install
 
+# CONTAINER_HOST is deliberately NOT baked here. It is set by the `dev` launcher
+# only when the host-root-equivalent runtime socket is actually mounted (opt-in).
+# Baking it unconditionally would pre-wire the image for the #191 escape path,
+# leaving the mount as the only missing piece. Set it where the socket lives.
 ENV PATH="/home/dev/.npm-global/bin:/home/dev/.local/bin:/home/dev/.nix-profile/bin:${PATH}" \
     NPM_CONFIG_PREFIX=/home/dev/.npm-global \
-    CONTAINER_HOST="unix:///var/run/docker.sock" \
     CLAUDE_CONFIG_DIR=/home/dev/.dev-state/claude \
     USER=dev \
     HOME=/home/dev
@@ -67,7 +70,7 @@ RUN set -eu; cd /home/dev/.dotfiles/nix \
 COPY --chown=dev:dev . /home/dev/.dotfiles
 
 # --- Docker/Podman CLI alias for Makefile compatibility ---
-# CONTAINER_HOST env var tells podman to use the mounted socket
+# Inert unless the launcher mounts the socket and sets CONTAINER_HOST (opt-in).
 RUN mkdir -p /home/dev/.local/bin \
     && printf '#!/bin/sh\nexec podman "$@"\n' > /home/dev/.local/bin/docker \
     && chmod +x /home/dev/.local/bin/docker

--- a/files/scripts/dev
+++ b/files/scripts/dev
@@ -86,8 +86,14 @@ if [ "${DEV_DOCKER_SOCK:-}" = "1" ] && [ -n "$PODMAN_SOCKET" ]; then
   # this gives the container full control of the host runtime: treat any code run
   # inside it (including Claude in dangerous mode) as running on the host. To
   # narrow this, front the socket with a docker-socket-proxy that exposes only
-  # the needed API surface and point DOCKER_HOST at the proxy instead.
-  socket_mount=(-v "$PODMAN_SOCKET:/var/run/docker.sock" --security-opt label=disable)
+  # the needed API surface and point CONTAINER_HOST at the proxy instead.
+  # CONTAINER_HOST is set here, not baked into the image, so the container is
+  # only ever pointed at a socket that is actually mounted (see Containerfile).
+  socket_mount=(
+    -v "$PODMAN_SOCKET:/var/run/docker.sock"
+    --security-opt label=disable
+    -e CONTAINER_HOST="unix:///var/run/docker.sock"
+  )
 fi
 
 # --- Build image ---


### PR DESCRIPTION
## What

Stop baking `CONTAINER_HOST=unix:///var/run/docker.sock` into the dev-container image. Set it in the `dev` launcher only inside the `socket_mount` block, so the container is pointed at the host runtime socket exactly when (and only when) that socket is opt-in mounted.

## Why (#191)

Issue #191 is a confirmed container-escape PoC: passwordless container-root reaches a bind-mounted host Podman socket via `CONTAINER_HOST`, drives the host daemon, and spawns a sibling container mounting `/Users`. Full host compromise.

The primary kill chain was already broken before this PR: the socket mount is opt-in, default-off, with loud warnings (#108/#119). The PoC was run with it on.

What remained was a latent loaded gun: the image advertised and pre-wired `CONTAINER_HOST` unconditionally, leaving the bind mount as the *only* missing piece. This removes that — the default no-socket config no longer pre-configures the escape path.

## Security review outcome

A security-analyst pass confirmed the default config is sound and ranked the remaining work:
- **Done here:** gate `CONTAINER_HOST` (the one real should-fix).
- **Defensible as-is, not changed:** passwordless `sudo` (neutralized by `--userns=keep-id` mapping container-root to the unprivileged host user; removing it is friction with no host-boundary gain) and the socket opt-in-with-warning (raw socket = host root is irreducible).

## Out of scope (operational, on the affected host — see #191 tasks)

- Delete `/Users/quinnherden/Desktop/flag` (PoC artifact; not reachable from this repo).
- Rotate credentials exposed during the live PoC.

## Test

- `code-reviewer` on the diff: clean (bash array expansion correct, no silent default-workflow breakage, comments accurate).
- Pre-commit `shellcheck`: passed.