### PR TITLE
fix(container): reset HEAD before checkout in dotfiles git init

### DIFF
--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -22,6 +22,7 @@ if [ -d /home/dev/.dotfiles ] && [ ! -d /home/dev/.dotfiles/.git ]; then
   if git clone --bare https://github.com/QuinnHerden/.dotfiles.git "$tmp"; then
     if mv "$tmp" /home/dev/.dotfiles/.git; then
       git -C /home/dev/.dotfiles config core.bare false
+      git -C /home/dev/.dotfiles reset HEAD
       git -C /home/dev/.dotfiles checkout -- .
       echo "Dotfiles repo ready." >&2
     else


### PR DESCRIPTION
## Summary

- Add `git reset HEAD` before `git checkout -- .` in the dotfiles git init block
- A bare clone has no index, so `checkout -- .` fails with "pathspec '.' did not match any file(s) known to git" without the reset

One-line fix on top of dae18ac.

## Test plan

- [x] Verified manually inside dev-banshee

🤖 Generated with [Claude Code](https://claude.com/claude-code)