### PR TITLE
feat(ci): add scheduled flake.lock update workflow

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -1,0 +1,39 @@
+name: Update flake.lock
+
+on:
+  schedule:
+    # Biweekly: 09:00 UTC on the 1st and 15th of each month
+    - cron: "0 9 1,15 * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  update:
+    name: update flake.lock
+    runs-on: ubuntu-latest
+    steps:
+      # Mint a short-lived token from the GitHub App so the resulting PR
+      # triggers CI workflows. PRs opened with the default GITHUB_TOKEN do
+      # not trigger other workflows (GitHub Actions safety limitation),
+      # which would leave the ci-required gate unrun and therefore moot.
+      - uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2
+        id: app-token
+        with:
+          app-id: ${{ vars.FLAKE_UPDATE_APP_ID }}
+          private-key: ${{ secrets.FLAKE_UPDATE_APP_KEY }}
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+      - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+      - uses: DeterminateSystems/update-flake-lock@a2bbe0274e3a0c4c8404f0b713a0f0aef741c59d # v25
+        with:
+          path-to-flake-dir: nix
+          token: ${{ steps.app-token.outputs.token }}
+          pr-title: "chore(nix): update flake.lock"
+          pr-body: |
+            Automated `nix flake update` run.
+
+            Review the input diffs below and merge once `ci-required` passes.
+          pr-labels: nix, dependencies


### PR DESCRIPTION
## Summary
- Add scheduled workflow to update `flake.lock` via `DeterminateSystems/update-flake-lock`
- Runs biweekly (1st and 15th at 09:00 UTC) and on manual `workflow_dispatch`
- Points at `nix/` subdirectory; labels resulting PRs `nix, dependencies`
- Uses a GitHub App via `actions/create-github-app-token` for auth — short-lived, auto-rotating tokens scoped to this repo. The default `GITHUB_TOKEN` can't be used because PRs it opens don't trigger CI workflows.
- No auto-merge — CI must pass, then a human merges

Closes #162

## Setup
1. Create a **GitHub App** (Settings → Developer settings → GitHub Apps) with **Contents: Read & Write** and **Pull requests: Read & Write** permissions
2. Install it on this repo only
3. Generate a private key
4. Add the App ID as a repo **variable** named `FLAKE_UPDATE_APP_ID`
5. Add the private key as a repo **secret** named `FLAKE_UPDATE_APP_KEY`

## Test plan
- [ ] Create the GitHub App and add credentials
- [ ] Trigger the workflow manually via `workflow_dispatch`
- [ ] Confirm a PR is opened with the correct `nix/flake.lock` diff
- [ ] Confirm CI workflows run on the opened PR
- [ ] Verify `nix, dependencies` labels are applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)