### PR TITLE
fix(ci): correct pinned SHAs for update-flake-lock workflow

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -18,7 +18,7 @@ jobs:
       # triggers CI workflows. PRs opened with the default GITHUB_TOKEN do
       # not trigger other workflows (GitHub Actions safety limitation),
       # which would leave the ci-required gate unrun and therefore moot.
-      - uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2
+      - uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         id: app-token
         with:
           app-id: ${{ vars.FLAKE_UPDATE_APP_ID }}
@@ -27,7 +27,7 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
       - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
-      - uses: DeterminateSystems/update-flake-lock@a2bbe0274e3a0c4c8404f0b713a0f0aef741c59d # v25
+      - uses: DeterminateSystems/update-flake-lock@b044cabb7988ec21289924a967891203e5630b2d # v9
         with:
           path-to-flake-dir: nix
           token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary
- Fix invalid commit SHAs for `actions/create-github-app-token` and `DeterminateSystems/update-flake-lock`
- `update-flake-lock` was pinned to a non-existent v25 SHA; corrected to v9

## Test plan
- [ ] Trigger `workflow_dispatch` and confirm the workflow runs past the action resolution step

🤖 Generated with [Claude Code](https://claude.com/claude-code)