### PR TITLE
fix(ci): use ./nix for path-to-flake-dir in update-flake-lock

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
       - uses: DeterminateSystems/update-flake-lock@b044cabb7988ec21289924a967891203e5630b2d # v9
         with:
-          path-to-flake-dir: nix
+          path-to-flake-dir: ./nix
           token: ${{ steps.app-token.outputs.token }}
           pr-title: "chore(nix): update flake.lock"
           pr-body: |


### PR DESCRIPTION
## Summary
- Fix flake discovery by using `./nix` instead of `nix` for `path-to-flake-dir`
- The action was searching at the repo root and failing with "not part of a flake"

## Test plan
- [ ] Trigger `workflow_dispatch` and confirm `nix flake update` runs in the correct directory