### PR TITLE
fix(ci): use latest update-flake-lock for path-to-flake-dir support

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
       - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
-      - uses: DeterminateSystems/update-flake-lock@b044cabb7988ec21289924a967891203e5630b2d # v9
+      - uses: DeterminateSystems/update-flake-lock@fd9359ac79d0e912f1b4b947a48470b3e2799b56 # main 2025-06-20
         with:
           path-to-flake-dir: ./nix
           token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary
- v9 uses a shell script that ignores `path-to-flake-dir`; latest main uses a node entrypoint that handles it correctly

## Test plan
- [ ] Trigger `workflow_dispatch` and confirm flake update runs in `nix/`