### PR TITLE
fix(zsh): guard zoxide init behind interactive shell check

### DIFF
--- a/nix/modules/home/content/base.nix
+++ b/nix/modules/home/content/base.nix
@@ -188,7 +188,7 @@
         export DOCKER_HOST="unix://$(podman machine inspect --format '{{.ConnectionInfo.PodmanSocket.Path}}' 2>/dev/null)"
       fi
 
-      eval "$(zoxide init --cmd cd zsh)"
+      [[ -o interactive ]] && eval "$(zoxide init --cmd cd zsh)"
     '';
   };
 


### PR DESCRIPTION
## Summary
- Guard `zoxide init` with `[[ -o interactive ]]` so it only runs in interactive shells
- Suppresses the "detected a possible configuration issue" warning when Claude Code or other tools run shell commands non-interactively

Closes #198