### PR TITLE
Add writing-storybrand skill; copy-writer uses contractions

### DIFF
--- a/files/home/.claude/agents/copy-writer.md
+++ b/files/home/.claude/agents/copy-writer.md
@@ -18,6 +18,7 @@ A fifth grader should understand it on the first read. Short sentences. One idea
 - Vary the rhythm. Mostly short. Drop in a very short one for punch.
 - Read every sentence aloud. If you run out of breath, or hear two ideas, break it up.
 - Use the simplest word that works. "Use" not "utilize." "Help" not "facilitate." "Show" not "demonstrate."
+- Contractions by default. "Don't" not "do not." "You're" not "you are." "What's" not "what is." "Can't," "won't," "it's," "we're." Spelling them out reads stiff and robotic; reserve the full form for rare, deliberate emphasis ("do NOT share your password").
 - Active voice with opinions: "Use WAU for B2B, not DAU" not "DAU may be less suitable for some B2B contexts."
 - Specificity: "At $2M ARR with 50 customers" not "at early stage."
 - Prose paragraphs for reasoning; tables only for genuine lists.

--- a/files/home/.claude/skills/writing-storybrand/SKILL.md
+++ b/files/home/.claude/skills/writing-storybrand/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: writing-storybrand
+description: Build a StoryBrand (Donald Miller SB7) BrandScript, calibrated to the market's awareness and sophistication. Use when the user wants a StoryBrand, SB7, BrandScript, brand story, messaging frame, or a one-liner, or to turn an offer/positioning into customer-facing messaging. Mentions: StoryBrand, SB7, BrandScript, brand story, one-liner.
+---
+
+# Writing a StoryBrand
+
+The SB7 framework and the Schwartz awareness/sophistication scales already live in the `copy-writer` agent and the knowledge extractions. A skilled writer working from instinct still skips three things. This skill exists to force those three gates **before any prose**, then hand off the build. Do not re-derive SB7 here; read it for depth (links at the bottom) and spend your effort on the gates.
+
+## Gate 1 — Resolve buyer / user / payer, then lock one hero
+
+Name three roles explicitly: who **pays**, who **uses**, who **feels the pain**. They are often different people (in offer docs "founder" usually means the seller, not the buyer).
+
+- The hero is the **pain-feeler**, almost never the payer or the founder/owner. The pain-feeler is the one with the survival-connected wound that drives the purchase, and usually the champion who sells the payer internally.
+- If payer and pain-feeler differ, the hero is still the pain-feeler; the payer gets a **separate companion asset**, never one script stretched across both.
+- Lock **one** hero and **one** desire (a single survival-connected want: status, time, security, meaning, resources). Write the choice and the reason in one line before continuing.
+
+## Gate 2 — Place the market on both Schwartz axes (fill this, do not skip it)
+
+State all three, and let them dictate the hook and the guide:
+
+- **Awareness** (1 Most aware to 5 Unaware): the state, and the move. Problem-aware or unaware: dramatize the problem or use an identification frame that echoes the buyer's private state; do **not** name the product in the hook.
+- **Sophistication** (1 First to 5 Exhausted): the stage, and the move. Stage 3+: lead with a **named mechanism** (a specific, named *how* you deliver what rivals structurally cannot). Stage 5: identification only; abandon claims. A named mechanism is not fabrication; an invented customer is.
+- **Proof on hand**: if none, authority runs on **gradualization** (a belief bridge from facts the buyer already accepts to the credential to the mechanism). Never fabricate proof, stats, clients, or logos.
+
+## Gate 3 — Name all four problem layers, the philosophical one explicitly
+
+Writers reliably fold the philosophical layer into the villain. Do not. Produce four distinct lines:
+
+- **Villain**: the root cause, singular, real, and **not a feeling**.
+- **External**: the tangible, surface problem.
+- **Internal**: the feeling it causes. This is what drives the buy.
+- **Philosophical**: the "ought not", why this is unjust. Name it as its own line.
+
+## Then build the SB7 script
+
+With the three gates locked, build (or hand the build to the writer running this skill): character + desire, the four problem layers, guide (empathy then authority; mechanism + gradualization; three proof points max; never fabricate), plan (process + agreement that removes fear), CTA (direct + transitional), failure (two to four stakes; a pinch of fear), success (the after), transformation (from to). Then the one-liner (character + problem + plan + success, one sentence) and a tagline. Grunt-test it: offer, benefit, next step, readable in five seconds.
+
+## Anti-patterns
+
+Brand as hero (competes with the customer) · only the external problem · the worn claim in a Stage 4 to 5 market · fabricated proof · fear by the bucket · a list of desires instead of one · the philosophical layer folded into the villain · one script stretched across a split buyer · closing the story gap before the sale.
+
+## Depth and handoff
+
+Frameworks (read for the parts you are unsure of): `~/.claude/knowledge/extractions/building-a-storybrand.md` (SB7, one-liner, grunt test, transformation), `~/.claude/knowledge/extractions/breakthrough-advertising.md` (the awareness and sophistication scales, the seven body-copy techniques), `~/.claude/knowledge/extractions/first-avatar.md` (avatar, value-in-advance). Read the project's offer or positioning docs for the offer that feeds the script.
+
+This skill produces the frozen BrandScript; the writer running it turns it into copy (you are already that writer). The one genuine outward handoff is `brand-strategist`, to vet positioning.


### PR DESCRIPTION
## What

- **New skill** `files/home/.claude/skills/writing-storybrand/` — builds a Donald Miller SB7 BrandScript. It deliberately does *not* re-teach SB7 (the `copy-writer` agent already holds it); instead it enforces the three gates a writer skips on instinct:
  1. Resolve buyer / user / payer, then lock the pain-feeler as hero.
  2. A forced two-axis Schwartz placement (awareness + sophistication) before any prose.
  3. Name all four problem layers, the philosophical one explicitly.
- **`copy-writer`** — add a "contractions by default" rule to the Style Guide (use `don't` / `you're` / `what's`, not the stiff spelled-out forms).

## Why

A stress-test (exercise + adversarial judge) of an earlier, fuller version of the skill showed it was a thin wrapper: a no-skill control produced the same Schwartz-calibrated output, because `copy-writer` already embeds SB7 + the awareness/sophistication scales. The skill was narrowed to only the gates the agent demonstrably misses, which a clean control confirmed it adds (it skipped the Schwartz placement and fumbled the split-buyer case).

The contraction rule fixes a recurring stiffness in copy-writer output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)